### PR TITLE
Code health cleanup: dead params, bytemuck, OnceLock, explicit pipeline layout, WASM build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,7 +1,8 @@
 name: github pages
 
-# Disabled: WASM build is currently broken. Re-enable once WASM is revived (see plan).
 on:
+  push:
+    branches: [master]
   workflow_dispatch:
 
 env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,9 +1075,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3063,10 +3065,10 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "fastrand",
+ "getrandom 0.3.4",
  "image",
  "int_grid",
  "js-sys",
- "lazy_static",
  "log",
  "pollster",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ winit = "0.30"
 log = "0.4"
 pollster = "0.3"
 scrub_log = "0.2"
-bytemuck = { version = "1.4", features = ["derive"] }
+bytemuck = { version = "1.15", features = ["derive"] }
 async-executor = "1.0"
 rand = "0.9"
 cgmath = "0.18"
@@ -25,7 +25,6 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 int_grid = {path = "int_grid"}
-lazy_static = "1"
 scarlet = "1"
 image = "0.25"
 fastrand = "1.7"
@@ -34,6 +33,7 @@ wgpu = "29"
 
 # TODO(wasm-revival): update these when reviving the WASM target
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
 console_error_panic_hook = "0.1.6"
 console_log = { version = "0.2", features = ["color"] }
 wasm-bindgen-futures = "0.4.20"

--- a/_context/plans/active/2026-03-22-code-health-cleanup.md
+++ b/_context/plans/active/2026-03-22-code-health-cleanup.md
@@ -15,22 +15,18 @@ Pre- and post-upgrade housekeeping. Items identified during the pre-upgrade audi
 
 ## Easy / mechanical (do next)
 
-- [ ] Remove `frame_num: i64` from `Render` (`src/render.rs:18`) — incremented every frame, never read
-- [ ] Remove dead demo texture machinery from `Render`: `show_demo_texture: bool`, `demo_model: Option<TexturedQuad>`, and the `load_image_to_texture` call at init — loads a texture unconditionally, allocates GPU memory, never toggled by any input; `pub show_demo_texture` is dead public API
-- [ ] Remove vestigial `_device: &wgpu::Device` params from four render methods — these became unused when StagingBelt internalized the device during the wgpu 29 upgrade:
-  - `Render::render()` (`src/render.rs:190`)
-  - `ShipRenderer::render()` (`src/ship.rs:199`)
-  - `TerrainRenderer::update_render_state()` (`src/level_manager.rs:545`)
-  - `ParticleSystem::run_compute()` (`src/particles.rs:281`)
-- [ ] Extract duplicated level budget constant in `main.rs` (lines 106 and 362): `Duration::from_secs_f64(1.0 / 300.0)` appears twice
-- [ ] Replace `lazy_static` with `OnceLock` (stable since 1.70) — no urgency, lazy_static still maintained
+- [x] Remove `frame_num: i64` from `Render` (`src/render.rs`) — done
+- [x] Remove dead demo texture machinery from `Render` — done
+- [x] Remove vestigial `_device: &wgpu::Device` params from four render methods — done (also fixed all callers and tests)
+- [x] Extract duplicated level budget constant in `main.rs` — `LEVEL_BUDGET: Duration = from_nanos(3_333_333)` at module level
+- [x] Replace `lazy_static` with `OnceLock` — done in `color_maps.rs`, `lazy_static` dep removed
 
 ---
 
 ## Moderate effort
 
-- [ ] Upgrade `bytemuck` to >= 1.15: `bytemuck_derive >= 1.5` switches Pod derives from `check` fn to `const` assertions, allowing removal of the documented `#![allow(dead_code)]` in `particles.rs`, `ship.rs`, `level_manager.rs`, `textured_quad.rs`; then narrow remaining `#[allow(dead_code)]` suppressions and re-assess what's genuinely unused
-- [ ] Convert draw pipeline to explicit pipeline layout in `render.rs` (existing TODO at line 108): currently uses `layout: None` (auto-layout via shader reflection), which is fragile against accidental shader/bind-group mismatches and blocks pipeline layout sharing
+- [x] Upgrade `bytemuck` to >= 1.15 — Cargo.toml updated to 1.15 (lock already had 1.25); removed all 4 file-level `#![allow(dead_code)]` bytemuck comments; narrowed remaining allows
+- [x] Convert draw pipeline to explicit pipeline layout in `render.rs` — explicit BGLs for group 0 (camera, 128B) and group 1 (tex/sampler/model-pose 64B), PipelineLayout wired in, TODO removed
 - [ ] Address "keep in sync with shader" TODOs in `particles.rs` — consider generating struct layout from shader or adding a static size assert
 
 ---

--- a/_context/plans/active/2026-03-22-six-hour-session.md
+++ b/_context/plans/active/2026-03-22-six-hour-session.md
@@ -1,0 +1,72 @@
+# Six-Hour Session Plan — 2026-03-22
+
+Code health focus. No new features. Ship collision detection deferred to next session.
+
+---
+
+## Phase 1 — Easy / Mechanical Cleanup (~1h) ✅
+
+All items from the code health plan, easy tier:
+
+- [x] Remove `frame_num: i64` from `Render` (`src/render.rs:18`) — incremented every frame, never read
+- [x] Remove dead demo texture machinery from `Render`: `show_demo_texture: bool`, `demo_model: Option<TexturedQuad>`, and the `load_image_to_texture` call at init
+- [x] Remove vestigial `_device: &wgpu::Device` params from four render methods:
+  - `Render::render()` (`src/render.rs`)
+  - `ShipRenderer::render()` (`src/ship.rs`)
+  - `TerrainRenderer::update_render_state()` (`src/level_manager.rs`)
+  - `ParticleSystem::run_compute()` (`src/particles.rs`) + `Emitter::run_compute()`
+- [x] Extract duplicated level budget constant in `main.rs`: `LEVEL_BUDGET: Duration = from_nanos(3_333_333)` at module level
+
+---
+
+## Phase 2 — `bytemuck` Upgrade (~1.5h) ✅
+
+- [x] Upgrade `bytemuck` to >= 1.15 in `Cargo.toml` (Cargo.lock already had 1.25.0)
+- [x] Verify `bytemuck_derive >= 1.5` is pulled in (already in lock as part of 1.25.0)
+- [x] Remove `#![allow(dead_code)]` from `particles.rs`, `ship.rs`, `level_manager.rs`, `textured_quad.rs`
+- [x] Narrow any remaining `#[allow(dead_code)]` suppressions and re-assess:
+  - `color_maps.rs`: `ColorMap` enum is genuinely dead (index doc), `#[allow]` kept
+  - `level_manager.rs`: `stripe_level` field genuinely unused, `#[allow]` kept
+- [x] Run `cargo test` — 5/5 pass
+
+---
+
+## Phase 3 — `lazy_static` → `OnceLock` (~1h) ✅
+
+- [x] Audit all `lazy_static!` usages — only one in `color_maps.rs`
+- [x] Replace with `std::sync::OnceLock` (COLOR_MAPS static + `color_maps()` init fn)
+- [x] Remove `lazy_static` from `Cargo.toml` dependencies
+- [x] Run `cargo clippy -- -D warnings` and `cargo test` — all pass
+
+---
+
+## Phase 4 — Explicit Pipeline Layout in `render.rs` (~1.5h) ✅
+
+- [x] Read existing TODO at `render.rs` and understand current auto-layout usage (`layout: None`)
+- [x] Create explicit `BindGroupLayout` for group 0 (camera uniform, 128 bytes, VERTEX)
+- [x] Create explicit `BindGroupLayout` for group 1 (texture/sampler/model-pose, FRAGMENT+VERTEX)
+- [x] Create `PipelineLayout` from both BGLs, wire into render pipeline descriptor
+- [x] Confirm no bind-group/shader mismatches — clippy + tests pass
+- [x] Remove the TODO comment
+
+---
+
+## Phase 5 — WASM Revival ✅ (partial)
+
+- [ ] Evaluate WebGPU vs WebGL2 as the rendering backend — document pros/cons (browser support, wgpu WASM compatibility, performance) and decide
+- [x] Re-enable `gh-pages.yml` — now triggers on push to master (+ workflow_dispatch retained)
+- [x] Audit and update WASM-specific feature flags in `Cargo.toml` — added `getrandom = { version = "0.3", features = ["wasm_js"] }` for wgpu 29 transitive dep
+- [x] Verify `wasm32-unknown-unknown` target builds: passes with `RUSTFLAGS=--cfg=web_sys_unstable_apis`
+- [x] Fix compilation errors against wgpu 29 WASM API surface — getrandom 0.3 wasm_js fix
+- [ ] Smoke-test in browser (or document what's still broken) — **known open issue**: `framework.rs` uses `pollster::block_on` for async wgpu init; on WASM this may fail because browser async can't be synchronously blocked. Needs `wasm-bindgen-futures::spawn_local` refactor or similar.
+- [x] Clean up WASM dependencies — removed `lazy_static` (no longer needed); getrandom now explicit
+
+---
+
+## Success Criteria ✅
+
+- [x] `cargo fmt --all -- --check` passes
+- [x] `cargo clippy -- -D warnings` passes
+- [x] `cargo test --verbose` passes (5/5 tests)
+- [x] All phases 1–4 fully completed
+- [x] Phase 5 WASM build passes; runtime browser smoke-test deferred (pollster async issue)

--- a/src/color_maps.rs
+++ b/src/color_maps.rs
@@ -10,17 +10,23 @@ enum ColorMap {
     Plasma = 3,
 }
 
-use lazy_static::lazy_static;
-lazy_static! {
-    static ref COLOR_MAPS: [scarlet::colormap::ListedColorMap; 4] = [
-        scarlet::colormap::ListedColorMap::viridis(),
-        scarlet::colormap::ListedColorMap::magma(),
-        scarlet::colormap::ListedColorMap::inferno(),
-        scarlet::colormap::ListedColorMap::plasma(),
-    ];
+use std::sync::OnceLock;
+
+static COLOR_MAPS: OnceLock<[scarlet::colormap::ListedColorMap; 4]> = OnceLock::new();
+
+fn color_maps() -> &'static [scarlet::colormap::ListedColorMap; 4] {
+    COLOR_MAPS.get_or_init(|| {
+        [
+            scarlet::colormap::ListedColorMap::viridis(),
+            scarlet::colormap::ListedColorMap::magma(),
+            scarlet::colormap::ListedColorMap::inferno(),
+            scarlet::colormap::ListedColorMap::plasma(),
+        ]
+    })
 }
+
 pub fn get_color_map_from_index(i: usize) -> &'static scarlet::colormap::ListedColorMap {
-    &COLOR_MAPS[i]
+    &color_maps()[i]
 }
 
 // Create a particle density color map rgba

--- a/src/level_manager.rs
+++ b/src/level_manager.rs
@@ -1,7 +1,3 @@
-// bytemuck_derive 1.4.1 generates a `check` fn for Pod impls that Rust flags as dead
-// code. FragmentUniforms fields are written via bytemuck but never read back in Rust.
-// TODO: remove when bytemuck_derive >= 1.5 lands (switches to const assertions).
-#![allow(dead_code)]
 use crate::buffer_util::{self, SizedBuffer};
 
 pub struct WIPRectangleLevel {
@@ -499,7 +495,6 @@ impl LevelManager {
         // TODO when a level is no longer needed, recycle the buffer.
 
         self.terrain_renderer.update_render_state(
-            device,
             game_params,
             viewport_offset,
             self.composite_tile.shape.start,
@@ -542,7 +537,6 @@ struct FragmentUniforms {
 impl TerrainRenderer {
     pub fn update_render_state(
         &mut self,
-        _device: &wgpu::Device,
         game_params: &super::game_params::GameParams,
         viewport_offset: i32,
         terrain_buffer_offset: i32,
@@ -759,7 +753,7 @@ mod tests {
 
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-        renderer.update_render_state(&device, &game_params, 0, 0, &mut encoder);
+        renderer.update_render_state(&game_params, 0, 0, &mut encoder);
         renderer.render(&target.view, &mut encoder);
         gpu::encode_texture_readback(
             &mut encoder,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ use spout::particles;
 use spout::render;
 use spout::ship;
 
+/// Time budget per frame for background level generation (≈ 1/300 s).
+const LEVEL_BUDGET: std::time::Duration = std::time::Duration::from_nanos(3_333_333);
+
 #[derive(Debug, Default)]
 struct GameState {
     input_state: InputState,
@@ -103,10 +106,9 @@ impl Spout {
     fn update_state(&mut self) {
         self.update_paused();
 
-        let level_budget = std::time::Duration::from_secs_f64(1.0 / 300.0);
         self.level_manager
             .level_maker
-            .work_until(std::time::Instant::now() + level_budget);
+            .work_until(std::time::Instant::now() + LEVEL_BUDGET);
 
         let (game_dt, wall_dt) = self.tick();
 
@@ -324,7 +326,7 @@ impl framework::Example for Spout {
         // Run compute pipeline(s).
         self.level_manager.compose_tiles(&mut encoder);
         self.particle_system
-            .run_compute(&self.level_manager, device, &mut encoder);
+            .run_compute(&self.level_manager, &mut encoder);
 
         // Render terrain.
         self.level_manager
@@ -341,14 +343,13 @@ impl framework::Example for Spout {
                 &self.state.ship_state,
                 &self.game_params,
                 self.state.viewport_offset,
-                device,
                 &self.game_view_texture,
                 &mut encoder,
             );
         }
 
         // Render the game view quad.
-        self.renderer.render(view, device, &mut encoder);
+        self.renderer.render(view, &mut encoder);
         self.level_manager.decompose_tiles(&mut encoder);
 
         queue.submit(Some(encoder.finish()));
@@ -359,8 +360,7 @@ impl framework::Example for Spout {
 
         {
             // After rendering, do some "async" work:
-            let level_budget = std::time::Duration::from_secs_f64(1.0 / 300.0);
-            let deadline = self.iteration_start + level_budget;
+            let deadline = self.iteration_start + LEVEL_BUDGET;
             self.level_manager.level_maker.work_until(deadline);
         }
     }

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -1,7 +1,3 @@
-// bytemuck_derive 1.4.1 generates a `check` fn for Pod impls that Rust flags as dead
-// code. These GPU layout structs are written via bytemuck but never read back in Rust.
-// TODO: remove when bytemuck_derive >= 1.5 lands (switches to const assertions).
-#![allow(dead_code)]
 use crate::buffer_util::{self, SizedBuffer};
 
 // This should match the struct defined in the relevant compute shader.
@@ -278,7 +274,7 @@ impl Emitter {
         }
     }
 
-    pub fn run_compute(&mut self, _device: &wgpu::Device, encoder: &mut wgpu::CommandEncoder) {
+    pub fn run_compute(&mut self, encoder: &mut wgpu::CommandEncoder) {
         if let Some(emit_params) = &self.emit_params {
             // Update uniforms
             // TODO reference https://toji.github.io/webgpu-best-practices/buffer-uploads.html
@@ -663,10 +659,9 @@ impl ParticleSystem {
     pub fn run_compute(
         &mut self,
         level_manager: &crate::level_manager::LevelManager,
-        device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
     ) {
-        self.emitter.run_compute(device, encoder);
+        self.emitter.run_compute(encoder);
 
         // Clear density buffer.
         // See https://docs.rs/wgpu/latest/wgpu/struct.CommandEncoder.html#method.clear_buffer
@@ -962,7 +957,7 @@ mod tests {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("Compute test encoder"),
         });
-        emitter.run_compute(device, &mut encoder);
+        emitter.run_compute(&mut encoder);
         encoder.copy_buffer_to_buffer(
             &emitter.particle_buffer.buffer,
             0,

--- a/src/render.rs
+++ b/src/render.rs
@@ -11,11 +11,7 @@ pub struct Render {
 
     draw_pipeline: wgpu::RenderPipeline,
 
-    pub show_demo_texture: bool,
     model: textured_quad::TexturedQuad,
-    demo_model: Option<textured_quad::TexturedQuad>,
-
-    frame_num: i64,
     staging_belt: wgpu::util::StagingBelt,
 }
 
@@ -61,7 +57,7 @@ impl Render {
         game_params: &crate::game_params::GameParams,
         _adapter: &wgpu::Adapter,
         device: &wgpu::Device,
-        queue: &wgpu::Queue,
+        _queue: &wgpu::Queue,
         texture_view: &wgpu::TextureView,
     ) -> Self {
         let mut camera = camera::Camera {
@@ -102,10 +98,63 @@ impl Render {
             source: wgpu::ShaderSource::Wgsl(crate::include_shader!("textured_model.wgsl")),
         });
 
+        // Group 0: camera uniforms (ViewData = projection + view, 2 × mat4x4<f32> = 128 bytes).
+        let camera_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Camera BGL"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(128),
+                },
+                count: None,
+            }],
+        });
+
+        // Group 1: texture (b0), sampler (b1), model-pose uniform (b2, mat4x4<f32> = 64 bytes).
+        let texture_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Texture BGL"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(64),
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Draw pipeline layout"),
+            bind_group_layouts: &[Some(&camera_bgl), Some(&texture_bgl)],
+            immediate_size: 0,
+        });
+
         let draw_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             label: Some("draw"),
-            // TODO convert this to explicit pipeline layout.
-            layout: None,
+            layout: Some(&pipeline_layout),
             vertex: wgpu::VertexState {
                 module: &shader,
                 entry_point: Some("vs_main"),
@@ -129,9 +178,8 @@ impl Render {
         });
 
         // Create bind group
-        let camera_bind_group_layout = draw_pipeline.get_bind_group_layout(0);
         let camera_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &camera_bind_group_layout,
+            layout: &camera_bgl,
             entries: &[wgpu::BindGroupEntry {
                 binding: 0,
                 resource: camera_uniform_buf.as_entire_binding(),
@@ -141,26 +189,11 @@ impl Render {
 
         let textured_quad = textured_quad::TexturedQuad::init(
             device,
-            draw_pipeline.get_bind_group_layout(1),
+            texture_bgl,
             texture_view,
             game_params.viewport_width,
             game_params.viewport_height,
         );
-
-        let maybe_demo_texture = crate::load_image::load_image_to_texture(device, queue);
-        let maybe_demo_quad = match maybe_demo_texture {
-            Ok(demo_texture) => Some(textured_quad::TexturedQuad::init(
-                device,
-                draw_pipeline.get_bind_group_layout(1),
-                &demo_texture,
-                game_params.viewport_width,
-                game_params.viewport_height,
-            )),
-            Err(e) => {
-                log::error!("Couldn't load demo texture: {:?}", e);
-                None
-            }
-        };
 
         // Aim the camera at the quad to start with.
         Render::reset_camera(&textured_quad, &mut camera);
@@ -171,11 +204,7 @@ impl Render {
             camera_uniform_buf,
             draw_pipeline,
 
-            show_demo_texture: false,
             model: textured_quad,
-            demo_model: maybe_demo_quad,
-
-            frame_num: 0,
             staging_belt: wgpu::util::StagingBelt::new(device.clone(), 0x100),
         }
     }
@@ -184,12 +213,7 @@ impl Render {
         self.camera.screen_size = (config.width, config.height);
     }
 
-    pub fn render(
-        &mut self,
-        view: &wgpu::TextureView,
-        _device: &wgpu::Device,
-        encoder: &mut wgpu::CommandEncoder,
-    ) {
+    pub fn render(&mut self, view: &wgpu::TextureView, encoder: &mut wgpu::CommandEncoder) {
         {
             let raw_uniforms = self.camera.to_uniform_data();
             self.staging_belt
@@ -234,17 +258,9 @@ impl Render {
                 rpass.set_bind_group(0, &self.camera_bind_group, &[]);
 
                 // Show the quad.
-                if !self.show_demo_texture {
-                    self.model.render(&mut rpass);
-                } else if let Some(quad) = &self.demo_model {
-                    quad.render(&mut rpass);
-                } else {
-                    self.model.render(&mut rpass);
-                }
+                self.model.render(&mut rpass);
             }
         }
-
-        self.frame_num += 1;
     }
 
     pub fn after_queue_submission(&mut self) {

--- a/src/ship.rs
+++ b/src/ship.rs
@@ -1,7 +1,3 @@
-// bytemuck_derive 1.4.1 generates a `check` fn for Pod impls that Rust flags as dead
-// code. These GPU layout structs are written via bytemuck but never read back in Rust.
-// TODO: remove when bytemuck_derive >= 1.5 lands (switches to const assertions).
-#![allow(dead_code)]
 use crate::{buffer_util::SizedBuffer, game_params};
 
 #[allow(clippy::upper_case_acronyms)]
@@ -196,7 +192,6 @@ impl ShipRenderer {
         state: &ShipState,
         game_params: &game_params::GameParams,
         viewport_offset: i32,
-        _device: &wgpu::Device,
         output_texture_view: &wgpu::TextureView,
         encoder: &mut wgpu::CommandEncoder,
     ) {
@@ -280,7 +275,7 @@ mod tests {
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         gpu::encode_clear_texture(&mut encoder, &target.view);
-        renderer.render(&state, &game_params, 0, &device, &target.view, &mut encoder);
+        renderer.render(&state, &game_params, 0, &target.view, &mut encoder);
         gpu::encode_texture_readback(
             &mut encoder,
             &target.texture,

--- a/src/textured_quad.rs
+++ b/src/textured_quad.rs
@@ -1,7 +1,3 @@
-// bytemuck_derive 1.4.1 generates a `check` fn for Pod impls that Rust flags as dead
-// code. The Vertex struct fields are written via bytemuck but never read back in Rust.
-// TODO: remove when bytemuck_derive >= 1.5 lands (switches to const assertions).
-#![allow(dead_code)]
 use bytemuck::{Pod, Zeroable};
 use wgpu::util::DeviceExt;
 


### PR DESCRIPTION
## Summary

- **Remove vestigial `_device` params** from `Render::render`, `ShipRenderer::render`, `TerrainRenderer::update_render_state`, `ParticleSystem::run_compute`, and `Emitter::run_compute` — these became unused when `StagingBelt` internalized the device in the wgpu 29 upgrade; all callers and tests updated
- **Extract `LEVEL_BUDGET` constant** — `Duration::from_secs_f64(1.0/300.0)` was duplicated in `main.rs`; replaced with `const LEVEL_BUDGET: Duration = Duration::from_nanos(3_333_333)`
- **bytemuck 1.4 → 1.15** — lock already had 1.25.0; removes the need for the file-level `#![allow(dead_code)]` workaround in `particles.rs`, `ship.rs`, `level_manager.rs`, `textured_quad.rs`
- **`lazy_static` → `std::sync::OnceLock`** — single usage in `color_maps.rs`; dep removed from `Cargo.toml`
- **Explicit pipeline layout in `render.rs`** — replaces `layout: None` (auto-layout) with explicit `BindGroupLayout`s for group 0 (camera uniform, 128 B) and group 1 (texture/sampler/model-pose, 64 B); removes the TODO comment
- **WASM build fix** — wgpu 29 transitively pulls in `getrandom` 0.3 which requires `wasm_js` feature on `wasm32-unknown-unknown`; added as explicit WASM target dep; re-enables `gh-pages.yml` on push to master

## Known open issue (WASM runtime)

The WASM *build* now passes but the game will deadlock in a browser. `framework.rs` uses `pollster::block_on` for the async wgpu init (`request_adapter` / `request_device`). On native this busy-spins the thread; in a browser the JS event loop can't run while the thread is blocked, so the underlying WebGPU Promises never resolve. Fix requires a `#[cfg(target_arch = "wasm32")]` path using `wasm_bindgen_futures::spawn_local` — tracked in the session plan for a follow-up PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --verbose` — 5/5 pass
- [x] `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build --target wasm32-unknown-unknown`

🤖 Generated with [Claude Code](https://claude.com/claude-code)