### PR TITLE
Migrate gh-pages deploy to official actions/deploy-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,11 +5,21 @@ on:
     branches: [master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one deployment at a time; cancel in-progress if a new push lands.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 env:
   RUSTFLAGS: --cfg=web_sys_unstable_apis
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,15 +36,24 @@ jobs:
       - name: Build WebGPU
         run: cargo build --release --target wasm32-unknown-unknown
 
-      - name: Generate JS bindings for WebGPU examples
+      - name: Generate JS bindings
         run: wasm-bindgen --no-typescript --out-dir target/spout_web --web target/wasm32-unknown-unknown/release/spout.wasm
 
       - name: Write html
         run: cat wasm-resources/index.template.html | sed "s/{{example}}/spout/g" > target/spout_web/index.html
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/master'
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/spout_web
+          path: ./target/spout_web
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Replaces `peaceiris/actions-gh-pages` (third-party, pushes to `gh-pages` branch) with the official `actions/upload-pages-artifact` + `actions/deploy-pages`
- Deployment status now shows in the repo sidebar and on PRs via GitHub's deployment API
- Split into separate `build` and `deploy` jobs
- Added `concurrency` group to cancel in-progress deployments on new pushes
- No more `GITHUB_TOKEN` write permission needed for branch pushing

## Required manual step before merging

**Settings → Pages → Build and deployment → Source → set to "GitHub Actions"**

This is what makes GitHub serve the artifact uploaded by the workflow instead of the stale `gh-pages` branch content.

## Test plan

- [ ] Merge and confirm the Actions run completes both `build` and `deploy` jobs
- [ ] Confirm https://glalonde.github.io/spout/ shows the working game

🤖 Generated with [Claude Code](https://claude.com/claude-code)