### PR TITLE
Add background music via oxdz tracker player

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,9 +103,9 @@ dependencies = [
  "jni-sys",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.44",
 ]
@@ -155,7 +177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -271,6 +293,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote 1.0.45",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,7 +414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -439,6 +479,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "cfg-expr"
@@ -507,6 +556,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,7 +574,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.10",
 ]
 
 [[package]]
@@ -601,6 +661,49 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "libc",
+]
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -714,6 +817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
 name = "deunicode"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,7 +929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -945,7 +1054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -1058,6 +1167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1220,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -1396,7 +1520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -1588,6 +1712,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1744,12 @@ checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "md5"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 
 [[package]]
 name = "memchr"
@@ -1681,7 +1820,7 @@ dependencies = [
  "log",
  "num-traits",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
@@ -1710,8 +1849,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -1723,7 +1876,7 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.44",
@@ -1734,6 +1887,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -1816,7 +1978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -1891,7 +2053,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -2155,6 +2317,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2371,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "oxdz"
+version = "0.1.0"
+source = "git+https://github.com/glalonde/oxdz?branch=master#55033354b2b2b31213adf0466c1edb84cc4fe065"
+dependencies = [
+ "byteorder",
+ "getopts",
+ "lazy_static",
+ "md5",
+ "save-restore-derive",
 ]
 
 [[package]]
@@ -2267,7 +2464,7 @@ dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -2337,7 +2534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -2453,7 +2650,7 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -2486,6 +2683,12 @@ checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -2754,6 +2957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,6 +3025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "save-restore-derive"
+version = "0.1.0"
+source = "git+https://github.com/glalonde/oxdz?branch=master#55033354b2b2b31213adf0466c1edb84cc4fe065"
+dependencies = [
+ "quote 0.3.15",
+ "syn 0.11.11",
 ]
 
 [[package]]
@@ -2894,7 +3112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -2960,7 +3178,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
- "quote",
+ "quote 1.0.45",
 ]
 
 [[package]]
@@ -3064,12 +3282,14 @@ dependencies = [
  "cgmath",
  "console_error_panic_hook",
  "console_log",
+ "cpal",
  "fastrand",
  "getrandom 0.3.4",
  "image",
  "int_grid",
  "js-sys",
  "log",
+ "oxdz",
  "pollster",
  "rand 0.9.2",
  "scarlet",
@@ -3105,12 +3325,23 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "unicode-ident",
 ]
 
@@ -3121,8 +3352,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "unicode-ident",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3201,7 +3441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -3212,7 +3452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -3418,6 +3658,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
 name = "v_frame"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3504,7 +3756,7 @@ version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
- "quote",
+ "quote 1.0.45",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3516,7 +3768,7 @@ checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
@@ -3624,7 +3876,7 @@ checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
 dependencies = [
  "proc-macro2",
  "quick-xml",
- "quote",
+ "quote 1.0.45",
 ]
 
 [[package]]
@@ -3717,7 +3969,7 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
@@ -3781,7 +4033,7 @@ dependencies = [
  "libloading",
  "log",
  "naga",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -3805,7 +4057,7 @@ dependencies = [
  "wgpu-naga-bridge",
  "wgpu-types",
  "windows 0.62.2",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3884,12 +4136,22 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -3900,7 +4162,17 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3912,7 +4184,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -3922,7 +4194,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
 ]
@@ -3934,7 +4206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -3945,7 +4217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 
@@ -3961,8 +4233,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4237,7 +4518,7 @@ dependencies = [
  "js-sys",
  "libc",
  "memmap2",
- "ndk",
+ "ndk 0.9.0",
  "objc2 0.5.2",
  "objc2-app-kit",
  "objc2-foundation 0.2.2",
@@ -4364,7 +4645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.117",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ image = "0.25"
 fastrand = "1.7"
 wgpu = "29"
 web-time = "1"
+oxdz = { git = "https://github.com/glalonde/oxdz", branch = "master" }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cpal = "0.15"
 
 
 # TODO(wasm-revival): update these when reviving the WASM target

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,0 +1,193 @@
+//! Background music player.
+//!
+//! Pre-renders one full loop of a tracker file to f32 PCM on a background
+//! thread, then plays it in a looping cpal stream (native) or Web Audio
+//! AudioBuffer (WASM, Phase 2).
+//!
+//! Usage:
+//!   let mut player = AudioPlayer::new();   // kicks off background render
+//!   // each frame:
+//!   player.poll();                         // picks up stream once ready
+
+// Tracker files embedded at compile time (~800 KB total).
+const TRACKS: &[&[u8]] = &[
+    include_bytes!("../assets/music/aurora.mod"),
+    include_bytes!("../assets/music/yoghurt_factory.xm"),
+    include_bytes!("../assets/music/aryx.s3m"),
+    include_bytes!("../assets/music/brainless_2.mod"),
+    include_bytes!("../assets/music/brainless_3.mod"),
+    include_bytes!("../assets/music/a_so_close.xm"),
+    include_bytes!("../assets/music/BUTTERFL.XM"),
+    include_bytes!("../assets/music/sexy3.xm"),
+    include_bytes!("../assets/music/MYDICKIN.MOD"),
+    include_bytes!("../assets/music/paul.mod"),
+    include_bytes!("../assets/music/radix-rainy_summerdays.mod"),
+    include_bytes!("../assets/music/spacedeb.mod"),
+    include_bytes!("../assets/music/z_bviinaaa.mod"),
+];
+
+fn render_track(bytes: &[u8]) -> Option<Vec<f32>> {
+    let mut player = oxdz::Oxdz::new(bytes, 44100, "")
+        .map_err(|e| log::error!("audio: failed to load track: {e}"))
+        .ok()?;
+
+    let mut fi = oxdz::FrameInfo::new();
+    let max_time_ms = 300_000.0f32; // 5-minute cap
+    let mut out = Vec::new();
+
+    loop {
+        player.frame_info(&mut fi);
+        if fi.loop_count > 0 || fi.time > max_time_ms {
+            break;
+        }
+        player.play_frame();
+        for &s in player.buffer() {
+            out.push(s as f32 / 32768.0);
+        }
+    }
+
+    log::info!(
+        "audio: rendered {:.1}s ({} samples)",
+        fi.time / 1000.0,
+        out.len()
+    );
+    Some(out)
+}
+
+// ── Native implementation ────────────────────────────────────────────────────
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::AudioPlayer;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use super::{render_track, TRACKS};
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc, Arc,
+    };
+
+    pub struct AudioPlayer {
+        /// Held alive to keep the cpal stream running.
+        _stream: Option<cpal::Stream>,
+        /// Receives rendered PCM from the background thread; stream is built
+        /// on the main thread (cpal::Stream is not Send on CoreAudio/macOS).
+        pending: Option<mpsc::Receiver<Vec<f32>>>,
+        track_index: usize,
+    }
+
+    impl AudioPlayer {
+        pub fn new() -> Self {
+            let mut player = AudioPlayer {
+                _stream: None,
+                pending: None,
+                track_index: 0,
+            };
+            player.start_track(0);
+            player
+        }
+
+        pub fn disabled() -> Self {
+            AudioPlayer {
+                _stream: None,
+                pending: None,
+                track_index: 0,
+            }
+        }
+
+        /// Call once per frame. Picks up rendered PCM and starts the cpal
+        /// stream the first time it's called after rendering finishes.
+        pub fn poll(&mut self) {
+            if let Some(rx) = self.pending.take() {
+                match rx.try_recv() {
+                    Ok(samples) => {
+                        if let Some(stream) = build_cpal_stream(samples) {
+                            if let Err(e) = stream.play() {
+                                log::error!("audio: failed to start stream: {e}");
+                            } else {
+                                self._stream = Some(stream);
+                            }
+                        }
+                    }
+                    Err(mpsc::TryRecvError::Empty) => self.pending = Some(rx),
+                    Err(mpsc::TryRecvError::Disconnected) => {
+                        log::warn!("audio: render thread exited without sending samples");
+                    }
+                }
+            }
+        }
+
+        pub fn next_track(&mut self) {
+            let next = (self.track_index + 1) % TRACKS.len();
+            self.start_track(next);
+        }
+
+        fn start_track(&mut self, index: usize) {
+            self._stream = None; // drop current stream immediately
+            self.track_index = index;
+            let (tx, rx) = mpsc::channel();
+
+            let track_bytes: &'static [u8] = TRACKS[index];
+            std::thread::spawn(move || {
+                if let Some(samples) = render_track(track_bytes) {
+                    let _ = tx.send(samples);
+                }
+            });
+
+            self.pending = Some(rx);
+        }
+    }
+
+    fn build_cpal_stream(samples: Vec<f32>) -> Option<cpal::Stream> {
+        let host = cpal::default_host();
+        let device = host.default_output_device().or_else(|| {
+            log::error!("audio: no output device found");
+            None
+        })?;
+
+        let config = cpal::StreamConfig {
+            channels: 2,
+            sample_rate: cpal::SampleRate(44100),
+            buffer_size: cpal::BufferSize::Default,
+        };
+
+        let samples = Arc::new(samples);
+        let pos = Arc::new(AtomicUsize::new(0));
+        let s = samples.clone();
+        let p = pos;
+
+        device
+            .build_output_stream(
+                &config,
+                move |out: &mut [f32], _| {
+                    let len = s.len();
+                    for sample in out.iter_mut() {
+                        let i = p.fetch_add(1, Ordering::Relaxed) % len;
+                        *sample = s[i];
+                    }
+                },
+                |e| log::error!("audio stream error: {e}"),
+                None,
+            )
+            .map_err(|e| log::error!("audio: failed to build stream: {e}"))
+            .ok()
+    }
+}
+
+// ── WASM stub (Phase 2 will implement Web Audio) ─────────────────────────────
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm_stub::AudioPlayer;
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_stub {
+    pub struct AudioPlayer;
+
+    impl AudioPlayer {
+        pub fn new() -> Self { AudioPlayer }
+        pub fn disabled() -> Self { AudioPlayer }
+        pub fn poll(&mut self) {}
+        pub fn next_track(&mut self) {}
+    }
+}

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -185,8 +185,12 @@ mod wasm_stub {
     pub struct AudioPlayer;
 
     impl AudioPlayer {
-        pub fn new() -> Self { AudioPlayer }
-        pub fn disabled() -> Self { AudioPlayer }
+        pub fn new() -> Self {
+            AudioPlayer
+        }
+        pub fn disabled() -> Self {
+            AudioPlayer
+        }
         pub fn poll(&mut self) {}
         pub fn next_track(&mut self) {}
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
+mod audio;
 #[path = "../examples/framework.rs"]
 mod framework;
-mod audio;
 
 use web_time::Instant;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #[path = "../examples/framework.rs"]
 mod framework;
+mod audio;
 
 use web_time::Instant;
 
@@ -33,6 +34,7 @@ struct Spout {
     renderer: render::Render,
     particle_system: particles::ParticleSystem,
     ship_renderer: ship::ShipRenderer,
+    audio: audio::AudioPlayer,
 }
 
 impl Spout {
@@ -106,6 +108,7 @@ impl Spout {
 
     /// Mostly responsible for updating superficial state based on new inputs.
     fn update_state(&mut self) {
+        self.audio.poll();
         self.update_paused();
 
         self.level_manager
@@ -230,6 +233,12 @@ impl framework::Example for Spout {
 
         queue.submit(Some(init_encoder.finish()));
 
+        let audio = if game_params.music_starts_on {
+            audio::AudioPlayer::new()
+        } else {
+            audio::AudioPlayer::disabled()
+        };
+
         Spout {
             game_params,
             state: game_state,
@@ -240,6 +249,7 @@ impl framework::Example for Spout {
             renderer,
             particle_system,
             ship_renderer,
+            audio,
         }
     }
 
@@ -275,6 +285,13 @@ impl framework::Example for Spout {
 
                 // Full screen
                 KeyCode::KeyF => self.state.input_state.fullscreen = pressed,
+
+                // Skip to next music track (on key-down only)
+                KeyCode::KeyT => {
+                    if pressed {
+                        self.audio.next_track();
+                    }
+                }
 
                 _ => {}
             }


### PR DESCRIPTION
## Summary

- Embeds all 13 tracker files (MOD/XM/S3M, ~800 KB total) via `include_bytes!`
- Pre-renders one full loop to f32 PCM on a background thread, then starts a looping `cpal` output stream — no audio stutter on the render thread
- Gated on `music_starts_on` in `game_config.toml` (currently `true`)
- Press **T** to skip to the next track
- WASM stub in place; Web Audio playback deferred to Phase 2

## Dependencies

- `oxdz` — pure-Rust MOD/XM/S3M player (our fork at `github.com/glalonde/oxdz`), fixed and modernized (Rust 2021, 0 warnings, audio bugs patched)
- `cpal = "0.15"` — native only

## Notes

- `cpal::Stream` is not `Send` on macOS/CoreAudio, so rendered PCM is sent back to the main thread via channel and the stream is built there
- No OGG files used — the tracker files are the source of truth; the `assets/music/output/` OGG directory can be deleted separately

## Test plan

- [ ] Launch game, hear music start within ~2s
- [ ] Press T, confirm track changes
- [ ] Set `music_starts_on = false`, confirm silence
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)