### PR TITLE
Fix mobile control latching: separate keyboard state from effective input

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,18 +1,18 @@
-name: Deploy to GitHub Pages (production)
+name: Deploy to GitHub Pages (canary)
+
+# Deploys the canary branch to https://glalonde.github.io/spout/canary/
+# Can also be triggered manually from any branch via workflow_dispatch.
 
 on:
   push:
-    branches: [master]
+    branches: [canary]
   workflow_dispatch:
 
-# Write permission is needed for peaceiris/actions-gh-pages to push the
-# gh-pages branch. No id-token / pages write needed with the branch approach.
 permissions:
   contents: write
 
-# One production deploy at a time; cancel the in-progress one if master moves.
 concurrency:
-  group: pages-production
+  group: pages-canary
   cancel-in-progress: true
 
 env:
@@ -35,8 +35,9 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
             target/
-          key: ${{ runner.os }}-wasm-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-wasm-canary-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-wasm-canary-
             ${{ runner.os }}-wasm-
 
       - name: Install wasm-bindgen-cli
@@ -53,10 +54,11 @@ jobs:
           sed "s/{{example}}/spout/g" wasm-resources/index.template.html \
             > target/spout_web/index.html
 
-      - name: Deploy to gh-pages (root)
+      - name: Deploy to gh-pages/canary
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/spout_web
-          # keep_files preserves the canary/ subdirectory written by canary.yml
+          destination_dir: canary
+          # keep_files preserves the root production deployment
           keep_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,37 @@ on:
     branches-ignore: [staging.tmp]
 
 jobs:
+  wasm-build:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: --cfg=web_sys_unstable_apis
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install WASM target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target/
+          key: ${{ runner.os }}-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-wasm-
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version 0.2.114 --locked
+      - name: Build WASM
+        run: cargo build --release --target wasm32-unknown-unknown
+      - name: Generate JS bindings
+        run: |
+          mkdir -p target/spout_web
+          wasm-bindgen --no-typescript --out-dir target/spout_web --web \
+            target/wasm32-unknown-unknown/release/spout.wasm
+          sed "s/{{example}}/spout/g" wasm-resources/index.template.html \
+            > target/spout_web/index.html
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,10 @@ const LEVEL_BUDGET: std::time::Duration = std::time::Duration::from_nanos(3_333_
 
 #[derive(Debug, Default)]
 struct GameState {
+    /// Pure keyboard state — set directly by key press/release events.
+    keyboard_input: InputState,
+    /// Effective input for the current frame: keyboard_input | mobile (WASM).
+    /// Recomputed from scratch each frame so mobile releases don't latch.
     input_state: InputState,
     prev_input_state: InputState,
     ship_state: ship::ShipState,
@@ -57,7 +61,7 @@ impl Spout {
     }
 
     fn update_paused(&mut self) {
-        if self.state.input_state.pause && !self.state.prev_input_state.pause {
+        if self.state.keyboard_input.pause && !self.state.prev_input_state.pause {
             // new pause signal.
             self.state.paused = !self.state.paused;
             if self.state.paused {
@@ -113,7 +117,10 @@ impl Spout {
 
     /// Mostly responsible for updating superficial state based on new inputs.
     fn update_state(&mut self) {
-        // Merge touch / accelerometer inputs from JS (WASM only).
+        // Rebuild effective input from the clean keyboard state so that a
+        // mobile release never latches. OR-merge mobile on top so both
+        // input sources can coexist.
+        self.state.input_state = self.state.keyboard_input;
         #[cfg(target_arch = "wasm32")]
         {
             self.state.input_state.forward |= mobile_input::get_forward();
@@ -295,23 +302,23 @@ impl framework::Example for Spout {
             let pressed = state == winit::event::ElementState::Pressed;
             match key {
                 // Ship motion bindings
-                KeyCode::KeyW => self.state.input_state.forward = pressed,
-                KeyCode::KeyA => self.state.input_state.left = pressed,
-                KeyCode::KeyP => self.state.input_state.pause = pressed,
-                KeyCode::KeyD => self.state.input_state.right = pressed,
+                KeyCode::KeyW => self.state.keyboard_input.forward = pressed,
+                KeyCode::KeyA => self.state.keyboard_input.left = pressed,
+                KeyCode::KeyP => self.state.keyboard_input.pause = pressed,
+                KeyCode::KeyD => self.state.keyboard_input.right = pressed,
 
                 // Camera bindings
-                KeyCode::KeyU => self.state.input_state.cam_in = pressed,
-                KeyCode::KeyO => self.state.input_state.cam_out = pressed,
-                KeyCode::KeyI => self.state.input_state.cam_up = pressed,
-                KeyCode::KeyK => self.state.input_state.cam_down = pressed,
-                KeyCode::KeyJ => self.state.input_state.cam_left = pressed,
-                KeyCode::KeyL => self.state.input_state.cam_right = pressed,
-                KeyCode::KeyN => self.state.input_state.cam_perspective = pressed,
-                KeyCode::KeyM => self.state.input_state.cam_reset = pressed,
+                KeyCode::KeyU => self.state.keyboard_input.cam_in = pressed,
+                KeyCode::KeyO => self.state.keyboard_input.cam_out = pressed,
+                KeyCode::KeyI => self.state.keyboard_input.cam_up = pressed,
+                KeyCode::KeyK => self.state.keyboard_input.cam_down = pressed,
+                KeyCode::KeyJ => self.state.keyboard_input.cam_left = pressed,
+                KeyCode::KeyL => self.state.keyboard_input.cam_right = pressed,
+                KeyCode::KeyN => self.state.keyboard_input.cam_perspective = pressed,
+                KeyCode::KeyM => self.state.keyboard_input.cam_reset = pressed,
 
                 // Full screen
-                KeyCode::KeyF => self.state.input_state.fullscreen = pressed,
+                KeyCode::KeyF => self.state.keyboard_input.fullscreen = pressed,
 
                 // Skip to next music track (on key-down only)
                 KeyCode::KeyT => {
@@ -360,7 +367,7 @@ impl framework::Example for Spout {
         window: &winit::window::Window,
     ) {
         {
-            if !self.state.prev_input_state.fullscreen && self.state.input_state.fullscreen {
+            if !self.state.prev_input_state.fullscreen && self.state.keyboard_input.fullscreen {
                 if window.fullscreen().is_some() {
                     // Set unfullscreen.
                     log::info!("Setting windowed mode.");


### PR DESCRIPTION
## Problem

The mobile OR-merge corrupted keyboard state, causing buttons to latch on after the first press:

```rust
// Bad — once true, can never go false via OR:
self.state.input_state.forward |= mobile_input::get_forward();
```

Trace:
1. Touch button pressed → `FORWARD = true` → OR-merge → `input_state.forward = true` ✓
2. Touch button released → `FORWARD = false` → OR-merge → `true |= false = true` ✗ (stuck!)

No keyboard event ever fires to reset `input_state.forward`, so thrust stays on forever.

## Fix (commit 1)

Add `keyboard_input: InputState` to `GameState`, written exclusively by key press/release events. Each frame `update_state()` rebuilds `input_state` fresh from `keyboard_input`, then OR-merges the current mobile `AtomicBool` values on top:

```rust
// Each frame:
self.state.input_state = self.state.keyboard_input;   // clean slate
self.state.input_state.forward |= mobile_input::get_forward();  // overlay
```

## WASM CI + canary deploy (commit 2)

**`ci.yml`**: adds a `wasm-build` job that runs on every PR alongside the native build. Catches WASM compilation failures before they hit master.

**`gh-pages.yml`**: migrated from the GitHub Actions API source (`actions/deploy-pages`) to branch-based (`peaceiris/actions-gh-pages`) to enable subdirectory control. Uses `keep_files: true` so canary isn't wiped on each production deploy.

**`canary.yml`**: new workflow — push to the `canary` branch (or trigger manually via `workflow_dispatch`) to deploy to `https://glalonde.github.io/spout/canary/`.

**One-time repo setup required after merge**: Settings → Pages → Source → "Deploy from a branch" → `gh-pages` / root.

## Test plan

- [ ] Touch thrust/left/right buttons — no latching; releasing a button stops the ship on the next frame
- [ ] Keyboard + touch coexist correctly
- [ ] `wasm-build` CI job goes green on this PR
- [ ] After merge: production deploy lands at the normal Pages URL
- [ ] After creating `canary` branch: canary deploy lands at `/canary/`

https://claude.ai/code/session_015KBaJpnSCSJAATUWokMDVZ