### PR TITLE
Replace cgmath with glam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,15 +148,6 @@ checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "approx"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
@@ -512,16 +503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "cgmath"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a98d30140e3296250832bbaaff83b27dcd6fa3cc70fb6f1f3e5c9c0023b5317"
-dependencies = [
- "approx 0.4.0",
- "num-traits",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,7 +555,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.1.10",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1141,7 +1122,7 @@ version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9705398c5c7b26132e74513f4ee7c1d7dafd786004991b375c172be2be0eecaa"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-traits",
  "rstar",
  "serde",
@@ -1172,7 +1153,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1220,6 +1201,12 @@ dependencies = [
  "log",
  "xml-rs",
 ]
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
 
 [[package]]
 name = "glob"
@@ -1828,7 +1815,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -3155,7 +3142,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
- "approx 0.5.1",
+ "approx",
  "num-complex",
  "num-traits",
  "paste",
@@ -3275,12 +3262,12 @@ dependencies = [
  "anyhow",
  "async-executor",
  "bytemuck",
- "cgmath",
  "console_error_panic_hook",
  "console_log",
  "cpal",
  "fastrand",
  "getrandom 0.3.4",
+ "glam",
  "image",
  "js-sys",
  "log",
@@ -3645,12 +3632,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ scrub_log = "0.2"
 bytemuck = { version = "1.15", features = ["derive"] }
 async-executor = "1.0"
 rand = "0.9"
-cgmath = "0.18"
+glam = "0.29"
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"

--- a/_context/plans/active/2026-03-22-code-health-cleanup.md
+++ b/_context/plans/active/2026-03-22-code-health-cleanup.md
@@ -33,7 +33,7 @@ Pre- and post-upgrade housekeeping. Items identified during the pre-upgrade audi
 
 ## Architectural / longer horizon
 
-- [ ] Replace `cgmath` with `glam` — better community adoption, more active development; significant find-and-replace but cleaner to do when touching math-heavy code anyway
+- [x] Replace `cgmath` with `glam` — replaced in `camera.rs`, `textured_quad.rs`, `examples/framework.rs`; all tests pass
 - [ ] Consolidate `StagingBelt` instances: currently 6 separate belts across `particles.rs` (x2), `level_manager.rs` (x2), `render.rs`, `ship.rs` — each holding a cloned `Arc<Device>`; a single shared belt at the top level would simplify ownership and allow better chunk sizing
 - [ ] Decouple update logic from render frequency: `Spout::update_state()` is called inside `Spout::render()` (`main.rs:315`), coupling physics tick rate to display frame rate; a fixed-rate update loop (or at minimum a capped `dt`) would make behavior frame-rate-independent
 - [ ] Add unit tests for camera math (spherical→Cartesian transforms) and buffer size calculations

--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -13,12 +13,12 @@ use winit::{
 
 #[rustfmt::skip]
 #[allow(unused)]
-pub const OPENGL_TO_WGPU_MATRIX: cgmath::Matrix4<f32> = cgmath::Matrix4::new(
+pub const OPENGL_TO_WGPU_MATRIX: glam::Mat4 = glam::Mat4::from_cols_array(&[
     1.0, 0.0, 0.0, 0.0,
     0.0, 1.0, 0.0, 0.0,
     0.0, 0.0, 0.5, 0.0,
     0.0, 0.0, 0.5, 1.0,
-);
+]);
 
 #[allow(dead_code)]
 pub trait Example: 'static + Sized {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -30,7 +30,7 @@ pub struct PerspectiveState {
 }
 
 pub struct CameraState {
-    pub center: cgmath::Point3<f32>,
+    pub center: glam::Vec3,
 
     // Camera in spherical coordinates.
     pub phi: f32,                              // Longitude.
@@ -43,7 +43,7 @@ pub struct CameraState {
 impl Default for CameraState {
     fn default() -> CameraState {
         CameraState {
-            center: cgmath::Point3::<f32>::new(0.0, 0.0, 0.0),
+            center: glam::Vec3::ZERO,
             phi: -PI / 2.0,
             theta: 0.0,
             radius: 1500.0,
@@ -54,18 +54,18 @@ impl Default for CameraState {
 }
 
 impl CameraState {
-    pub fn pos(&self) -> cgmath::Point3<f32> {
-        cgmath::Point3::new(
+    pub fn pos(&self) -> glam::Vec3 {
+        glam::Vec3::new(
             self.radius * self.phi.cos() * self.theta.sin(),
             self.radius * self.phi.sin() * self.theta.sin(),
             self.radius * self.theta.cos(),
-        ) + cgmath::Vector3::<f32>::new(self.center.x, self.center.y, self.center.z)
+        ) + self.center
     }
 
-    pub fn up(&self) -> cgmath::Vector3<f32> {
+    pub fn up(&self) -> glam::Vec3 {
         // Using spherical coordinates compute the vector in the global frame that corresponds to up in the camera's frame.
         let up_theta = self.theta - PI / 2.0;
-        cgmath::Vector3::new(
+        glam::Vec3::new(
             self.phi.cos() * up_theta.sin(),
             self.phi.sin() * up_theta.sin(),
             up_theta.cos(),
@@ -131,7 +131,7 @@ impl Camera {
                 let required_height = target_width / aspect;
                 let new_bottom = -required_height / 2.0;
                 let new_top = required_height / 2.0;
-                cgmath::ortho(
+                glam::Mat4::orthographic_rh_gl(
                     ortho_state.left,
                     ortho_state.right,
                     new_bottom,
@@ -144,7 +144,7 @@ impl Camera {
                 let required_width = aspect * target_height;
                 let new_left = -required_width / 2.0;
                 let new_right = required_width / 2.0;
-                cgmath::ortho(
+                glam::Mat4::orthographic_rh_gl(
                     new_left,
                     new_right,
                     ortho_state.bottom,
@@ -154,15 +154,15 @@ impl Camera {
                 )
             }
         } else if let Some(perspective_state) = &self.state.perspective {
-            cgmath::perspective(cgmath::Rad(perspective_state.fov), aspect, 1e-6, 10000.0)
+            glam::Mat4::perspective_rh_gl(perspective_state.fov, aspect, 1e-6, 10000.0)
         } else {
-            cgmath::perspective(cgmath::Deg(45f32), aspect, 1e-6, 10000.0)
+            glam::Mat4::perspective_rh_gl(45f32.to_radians(), aspect, 1e-6, 10000.0)
         };
 
         // camera_pose_world
         let cam_pos = self.state.pos();
         let cam_up = self.state.up();
-        let mx_view = cgmath::Matrix4::look_at_rh(cam_pos, self.state.center, cam_up);
+        let mx_view = glam::Mat4::look_at_rh(cam_pos, self.state.center, cam_up);
         let proj = framework::OPENGL_TO_WGPU_MATRIX * mx_projection;
         let view = framework::OPENGL_TO_WGPU_MATRIX * mx_view;
 
@@ -198,7 +198,7 @@ impl Camera {
         }
         self.state.ortho = Some(ortho_state);
         self.state.perspective = None;
-        self.state.center = cgmath::Point3::<f32>::new(center[0], center[1], 0.0);
+        self.state.center = glam::Vec3::new(center[0], center[1], 0.0);
     }
 
     pub fn perspective_look_at(
@@ -217,7 +217,7 @@ impl Camera {
 
         self.state.perspective = Some(perspective_state);
         self.state.ortho = None;
-        self.state.center = cgmath::Point3::<f32>::new(center[0], center[1], 0.0);
+        self.state.center = glam::Vec3::new(center[0], center[1], 0.0);
     }
 
     pub fn update_state(&mut self, dt: f32, input_state: &crate::input::InputState) {

--- a/src/textured_quad.rs
+++ b/src/textured_quad.rs
@@ -77,11 +77,7 @@ impl TexturedQuad {
         });
 
         // Model pose uniform
-        let model_pose = cgmath::Matrix4::from_translation(cgmath::Vector3 {
-            x: 0.0,
-            y: 0.0,
-            z: 0.0,
-        });
+        let model_pose = glam::Mat4::IDENTITY;
         let pose_uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Uniform Buffer"),
             contents: bytemuck::cast_slice(&AsRef::<[f32; 16]>::as_ref(&model_pose)[..]),


### PR DESCRIPTION
## Summary

- Replaces `cgmath` dependency with `glam` across the codebase
- `glam` has broader community adoption and more active maintenance than `cgmath`
- Change is entirely mechanical: `Mat4`/`Vec3` replace `Matrix4`/`Point3`/`Vector3` in `camera.rs`, `textured_quad.rs`, and `examples/framework.rs`
- `OPENGL_TO_WGPU_MATRIX` constant updated to `glam::Mat4`
- Removes `cgmath = "0.18"` from `Cargo.toml`, adds `glam = "0.29"`

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --verbose` passes (7/7 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)