### PR TITLE
Consolidate StagingBelt instances

### DIFF
--- a/src/level_manager.rs
+++ b/src/level_manager.rs
@@ -236,8 +236,6 @@ pub struct LevelManager {
 
     unused_buffers: Vec<SizedBuffer>,
 
-    staging_belt: wgpu::util::StagingBelt,
-
     pub level_maker: LevelMaker,
 
     pub terrain_renderer: TerrainRenderer,
@@ -302,6 +300,7 @@ impl LevelManager {
         game_params: &super::game_params::GameParams,
         viewport_offset: i32,
         init_encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
     ) -> Self {
         let level_width = game_params.level_width;
         let level_height = game_params.level_height;
@@ -329,8 +328,6 @@ impl LevelManager {
             active_interval_height as usize,
             "CompositeTerrainBuffer",
         );
-        let staging_belt =
-            wgpu::util::StagingBelt::new(device.clone(), (unused_buffers[0].size / 2) as u64);
         let renderer = TerrainRenderer::init(device, game_params, &composite_tile_buffer);
 
         let mut lm = LevelManager {
@@ -347,7 +344,6 @@ impl LevelManager {
             },
 
             unused_buffers,
-            staging_belt,
             level_maker: LevelMaker::init(
                 level_width,
                 level_height,
@@ -356,7 +352,7 @@ impl LevelManager {
             terrain_renderer: renderer,
         };
 
-        lm.sync_height(device, viewport_offset, init_encoder, game_params);
+        lm.sync_height(device, viewport_offset, init_encoder, game_params, belt);
         lm
     }
 
@@ -387,13 +383,13 @@ impl LevelManager {
         device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         active_levels: Interval,
+        belt: &mut wgpu::util::StagingBelt,
     ) {
         for level_index in active_levels.start..active_levels.end {
             assert!(level_index < self.level_maker.levels.len() as i32);
             // Check if this level has a buffer, if not, find it one.
-            // self.level_maker.use_level(check_level_index, action);
             // entry() API can't be used here: the block borrows self mutably
-            // (get_unused_tile_buffer, staging_belt) which conflicts with holding an Entry.
+            // (get_unused_tile_buffer) which conflicts with holding an Entry.
             #[allow(clippy::map_entry)]
             if !self.loaded_tiles.contains_key(&level_index) {
                 // Tile isn't loaded, find a buffer.
@@ -403,14 +399,13 @@ impl LevelManager {
                 // let level_data = &self.stripe_level;
 
                 // Request data copy.
-                self.staging_belt
-                    .write_buffer(
-                        encoder,
-                        &buffer.buffer,
-                        0,
-                        wgpu::BufferSize::new(buffer.size as _).unwrap(),
-                    )
-                    .copy_from_slice(bytemuck::cast_slice(level_data));
+                belt.write_buffer(
+                    encoder,
+                    &buffer.buffer,
+                    0,
+                    wgpu::BufferSize::new(buffer.size as _).unwrap(),
+                )
+                .copy_from_slice(bytemuck::cast_slice(level_data));
                 let level_start = level_index * self.level_height as i32;
                 self.loaded_tiles.insert(
                     level_index,
@@ -424,8 +419,6 @@ impl LevelManager {
                 );
             }
         }
-
-        self.staging_belt.finish();
     }
 
     pub fn get_active_interval(
@@ -461,6 +454,7 @@ impl LevelManager {
         viewport_offset: i32,
         encoder: &mut wgpu::CommandEncoder,
         game_params: &crate::game_params::GameParams,
+        belt: &mut wgpu::util::StagingBelt,
     ) {
         log::debug!("Syncing to height: {}", viewport_offset);
         self.update_active_interval(viewport_offset);
@@ -491,7 +485,7 @@ impl LevelManager {
 
         // Find levels we need, make sure they're done (blocking) and loaded into the gpu(blocking)
         self.block_on_levels(active_levels);
-        self.load_active_levels(device, encoder, active_levels);
+        self.load_active_levels(device, encoder, active_levels, belt);
 
         // TODO when a level is no longer needed, recycle the buffer.
 
@@ -500,12 +494,8 @@ impl LevelManager {
             viewport_offset,
             self.composite_tile.shape.start,
             encoder,
+            belt,
         );
-    }
-
-    pub fn after_queue_submission(&mut self) {
-        self.terrain_renderer.after_queue_submission();
-        self.staging_belt.recall();
     }
 }
 
@@ -522,7 +512,6 @@ pub struct TerrainRenderer {
     pub render_bind_group: wgpu::BindGroup,
     pub render_pipeline: wgpu::RenderPipeline,
     pub uniform_buf: SizedBuffer,
-    staging_belt: wgpu::util::StagingBelt,
 }
 
 #[repr(C)]
@@ -542,6 +531,7 @@ impl TerrainRenderer {
         viewport_offset: i32,
         terrain_buffer_offset: i32,
         encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
     ) {
         let uniforms = FragmentUniforms {
             viewport_width: game_params.level_width,
@@ -551,15 +541,13 @@ impl TerrainRenderer {
         };
 
         // Update uniforms
-        self.staging_belt
-            .write_buffer(
-                encoder,
-                &self.uniform_buf.buffer,
-                0,
-                wgpu::BufferSize::new(self.uniform_buf.size as _).unwrap(),
-            )
-            .copy_from_slice(bytemuck::bytes_of(&uniforms));
-        self.staging_belt.finish();
+        belt.write_buffer(
+            encoder,
+            &self.uniform_buf.buffer,
+            0,
+            wgpu::BufferSize::new(self.uniform_buf.size as _).unwrap(),
+        )
+        .copy_from_slice(bytemuck::bytes_of(&uniforms));
     }
 
     pub fn init(
@@ -668,13 +656,10 @@ impl TerrainRenderer {
             multiview_mask: None,
         });
 
-        let staging_belt = wgpu::util::StagingBelt::new(device.clone(), uniform_buf.size);
-
         TerrainRenderer {
             render_bind_group,
             render_pipeline,
             uniform_buf,
-            staging_belt,
         }
     }
 
@@ -703,10 +688,6 @@ impl TerrainRenderer {
         rpass.set_pipeline(&self.render_pipeline);
         rpass.set_bind_group(0, &self.render_bind_group, &[]);
         rpass.draw(0..4_u32, 0..1);
-    }
-
-    pub fn after_queue_submission(&mut self) {
-        self.staging_belt.recall();
     }
 }
 
@@ -752,10 +733,11 @@ mod tests {
         let staging_buffer = gpu::create_readback_buffer(&device, TEST_W, TEST_H, 8);
 
         let mut renderer = TerrainRenderer::init(&device, &game_params, &terrain_buffer);
+        let mut belt = wgpu::util::StagingBelt::new(device.clone(), 256);
 
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-        renderer.update_render_state(&game_params, 0, 0, &mut encoder);
+        renderer.update_render_state(&game_params, 0, 0, &mut encoder, &mut belt);
         renderer.render(&target.view, &mut encoder);
         gpu::encode_texture_readback(
             &mut encoder,
@@ -765,8 +747,9 @@ mod tests {
             TEST_H,
             8,
         );
+        belt.finish();
         queue.submit(Some(encoder.finish()));
-        renderer.after_queue_submission();
+        belt.recall();
 
         let raw = gpu::readback_pixels(&device, &staging_buffer);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ struct Spout {
     particle_system: particles::ParticleSystem,
     ship_renderer: ship::ShipRenderer,
     audio: audio::AudioPlayer,
+    staging_belt: wgpu::util::StagingBelt,
 }
 
 impl Spout {
@@ -224,8 +225,19 @@ impl framework::Example for Spout {
         let mut init_encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
 
-        let level_manager =
-            level_manager::LevelManager::init(device, &game_params, 0, &mut init_encoder);
+        // Chunk size covers one terrain tile upload; the belt grows as needed.
+        let mut staging_belt = wgpu::util::StagingBelt::new(
+            device.clone(),
+            (game_params.level_width * game_params.level_height * 4) as u64,
+        );
+
+        let level_manager = level_manager::LevelManager::init(
+            device,
+            &game_params,
+            0,
+            &mut init_encoder,
+            &mut staging_belt,
+        );
 
         let renderer = render::Render::init(
             config,
@@ -243,7 +255,9 @@ impl framework::Example for Spout {
 
         let ship_renderer = ship::ShipRenderer::init(device);
 
+        staging_belt.finish();
         queue.submit(Some(init_encoder.finish()));
+        staging_belt.recall();
 
         let audio = if game_params.music_starts_on {
             audio::AudioPlayer::new()
@@ -278,6 +292,7 @@ impl framework::Example for Spout {
             particle_system,
             ship_renderer,
             audio,
+            staging_belt,
         }
     }
 
@@ -362,12 +377,13 @@ impl framework::Example for Spout {
             self.state.viewport_offset,
             &mut encoder,
             &self.game_params,
+            &mut self.staging_belt,
         );
 
         // Run compute pipeline(s).
         self.level_manager.compose_tiles(&mut encoder);
         self.particle_system
-            .run_compute(&self.level_manager, &mut encoder);
+            .run_compute(&self.level_manager, &mut encoder, &mut self.staging_belt);
 
         // Render terrain.
         self.level_manager
@@ -386,11 +402,13 @@ impl framework::Example for Spout {
                 self.state.viewport_offset,
                 &self.game_view_texture,
                 &mut encoder,
+                &mut self.staging_belt,
             );
         }
 
         // Blit game view (240×135) → upscaled HDR (surface resolution).
-        self.renderer.blit(&self.upscaled_view, &mut encoder);
+        self.renderer
+            .blit(&self.upscaled_view, &mut encoder, &mut self.staging_belt);
 
         // Run bloom post-process at full surface resolution (threshold + blur).
         self.bloom.render(&mut encoder);
@@ -399,11 +417,9 @@ impl framework::Example for Spout {
         self.renderer.render(view, &mut encoder);
         self.level_manager.decompose_tiles(&mut encoder);
 
+        self.staging_belt.finish();
         queue.submit(Some(encoder.finish()));
-        self.ship_renderer.after_queue_submission();
-        self.particle_system.after_queue_submission();
-        self.renderer.after_queue_submission();
-        self.level_manager.after_queue_submission();
+        self.staging_belt.recall();
 
         {
             // After rendering, do some "async" work:

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -38,7 +38,6 @@ pub struct Emitter {
     uniform_buffer: SizedBuffer,
     pub particle_buffer: SizedBuffer,
     compute_pipeline: wgpu::ComputePipeline,
-    staging_belt: wgpu::util::StagingBelt,
 }
 
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
@@ -225,8 +224,6 @@ impl Emitter {
             ],
         });
 
-        let staging_belt = wgpu::util::StagingBelt::new(device.clone(), uniform_buffer.size);
-
         Emitter {
             params: EmitterParams {
                 num_particles: max_num_particles,
@@ -249,7 +246,6 @@ impl Emitter {
             uniform_buffer,
             particle_buffer,
             compute_pipeline,
-            staging_belt,
         }
     }
 
@@ -278,19 +274,21 @@ impl Emitter {
         }
     }
 
-    pub fn run_compute(&mut self, encoder: &mut wgpu::CommandEncoder) {
+    pub fn run_compute(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
+    ) {
         if let Some(emit_params) = &self.emit_params {
             // Update uniforms
             // TODO reference https://toji.github.io/webgpu-best-practices/buffer-uploads.html
-            self.staging_belt
-                .write_buffer(
-                    encoder,
-                    &self.uniform_buffer.buffer,
-                    0,
-                    wgpu::BufferSize::new(self.uniform_buffer.size as _).unwrap(),
-                )
-                .copy_from_slice(bytemuck::bytes_of(emit_params));
-            self.staging_belt.finish();
+            belt.write_buffer(
+                encoder,
+                &self.uniform_buffer.buffer,
+                0,
+                wgpu::BufferSize::new(self.uniform_buffer.size as _).unwrap(),
+            )
+            .copy_from_slice(bytemuck::bytes_of(emit_params));
 
             {
                 let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
@@ -314,10 +312,6 @@ impl Emitter {
             self.emit_params = None;
         }
     }
-
-    pub fn after_queue_submission(&mut self) {
-        self.staging_belt.recall();
-    }
 }
 
 pub struct ParticleSystem {
@@ -326,7 +320,6 @@ pub struct ParticleSystem {
 
     // GPU interface cruft
     uniform_buffer: SizedBuffer,
-    staging_belt: wgpu::util::StagingBelt,
 
     update_particles_work_groups: u32,
     update_particles_pipeline: wgpu::ComputePipeline,
@@ -620,7 +613,6 @@ impl ParticleSystem {
 
         let emitter = Emitter::new(device, game_params);
 
-        let staging_belt = wgpu::util::StagingBelt::new(device.clone(), uniform_buffer.size);
         let renderer = ParticleRenderer::init(device, game_params, &density_buffer, init_encoder);
 
         // Set up all the clear density buffer compute pass.
@@ -641,7 +633,6 @@ impl ParticleSystem {
             emitter,
             uniform_values,
             uniform_buffer,
-            staging_belt,
 
             update_particles_work_groups,
             update_particles_pipeline,
@@ -659,8 +650,9 @@ impl ParticleSystem {
         &mut self,
         level_manager: &crate::level_manager::LevelManager,
         encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
     ) {
-        self.emitter.run_compute(encoder);
+        self.emitter.run_compute(encoder, belt);
 
         // Clear density buffer.
         // See https://docs.rs/wgpu/latest/wgpu/struct.CommandEncoder.html#method.clear_buffer
@@ -691,15 +683,13 @@ impl ParticleSystem {
 
         {
             // Update uniforms
-            self.staging_belt
-                .write_buffer(
-                    encoder,
-                    &self.uniform_buffer.buffer,
-                    0,
-                    wgpu::BufferSize::new(self.uniform_buffer.size as _).unwrap(),
-                )
-                .copy_from_slice(bytemuck::bytes_of(&self.uniform_values));
-            self.staging_belt.finish();
+            belt.write_buffer(
+                encoder,
+                &self.uniform_buffer.buffer,
+                0,
+                wgpu::BufferSize::new(self.uniform_buffer.size as _).unwrap(),
+            )
+            .copy_from_slice(bytemuck::bytes_of(&self.uniform_values));
 
             let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
                 label: Some("Particle System"),
@@ -718,11 +708,6 @@ impl ParticleSystem {
         encoder: &mut wgpu::CommandEncoder,
     ) {
         self.renderer.render(encoder, game_view_texture);
-    }
-
-    pub fn after_queue_submission(&mut self) {
-        self.emitter.after_queue_submission();
-        self.staging_belt.recall();
     }
 }
 
@@ -953,10 +938,11 @@ mod tests {
             mapped_at_creation: false,
         });
 
+        let mut belt = wgpu::util::StagingBelt::new(device.clone(), 256);
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("Compute test encoder"),
         });
-        emitter.run_compute(&mut encoder);
+        emitter.run_compute(&mut encoder, &mut belt);
         encoder.copy_buffer_to_buffer(
             &emitter.particle_buffer.buffer,
             0,
@@ -964,8 +950,9 @@ mod tests {
             0,
             emitter.particle_buffer.size,
         );
+        belt.finish();
         queue.submit(Some(encoder.finish()));
-        emitter.after_queue_submission();
+        belt.recall();
 
         let buffer_slice = staging_buffer.slice(..);
         buffer_slice.map_async(wgpu::MapMode::Read, |_| {});

--- a/src/render.rs
+++ b/src/render.rs
@@ -12,7 +12,6 @@ pub struct Render {
     draw_pipeline: wgpu::RenderPipeline,
 
     model: textured_quad::TexturedQuad,
-    staging_belt: wgpu::util::StagingBelt,
 
     // Composite pass: upscaled HDR + bloom → surface (LDR).
     composite_bgl: wgpu::BindGroupLayout,
@@ -338,7 +337,6 @@ impl Render {
             camera_uniform_buf,
             draw_pipeline,
             model: textured_quad,
-            staging_belt: wgpu::util::StagingBelt::new(device.clone(), 0x100),
             composite_bgl,
             composite_pipeline,
             composite_bind_group,
@@ -358,19 +356,21 @@ impl Render {
     }
 
     /// Blit the game view (240×135) into the upscaled HDR texture at surface resolution.
-    pub fn blit(&mut self, upscaled_view: &wgpu::TextureView, encoder: &mut wgpu::CommandEncoder) {
+    pub fn blit(
+        &mut self,
+        upscaled_view: &wgpu::TextureView,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
+    ) {
         {
             let raw_uniforms = self.camera.to_uniform_data();
-            self.staging_belt
-                .write_buffer(
-                    encoder,
-                    &self.camera_uniform_buf,
-                    0,
-                    wgpu::BufferSize::new((raw_uniforms.len() * 4) as wgpu::BufferAddress).unwrap(),
-                )
-                .copy_from_slice(bytemuck::cast_slice(&raw_uniforms));
-
-            self.staging_belt.finish();
+            belt.write_buffer(
+                encoder,
+                &self.camera_uniform_buf,
+                0,
+                wgpu::BufferSize::new((raw_uniforms.len() * 4) as wgpu::BufferAddress).unwrap(),
+            )
+            .copy_from_slice(bytemuck::cast_slice(&raw_uniforms));
         }
 
         {
@@ -429,9 +429,5 @@ impl Render {
         rpass.set_pipeline(&self.composite_pipeline);
         rpass.set_bind_group(0, &self.composite_bind_group, &[]);
         rpass.draw(0..4, 0..1);
-    }
-
-    pub fn after_queue_submission(&mut self) {
-        self.staging_belt.recall();
     }
 }

--- a/src/ship.rs
+++ b/src/ship.rs
@@ -83,7 +83,6 @@ pub struct ShipRenderer {
     render_bind_group: wgpu::BindGroup,
     render_pipeline: wgpu::RenderPipeline,
     outline_pipeline: wgpu::RenderPipeline,
-    staging_belt: wgpu::util::StagingBelt,
 }
 
 impl ShipRenderer {
@@ -199,13 +198,11 @@ impl ShipRenderer {
             multiview_mask: None,
         });
 
-        let staging_belt = wgpu::util::StagingBelt::new(device.clone(), uniform_buffer.size);
         ShipRenderer {
             uniform_buffer,
             render_bind_group,
             render_pipeline,
             outline_pipeline,
-            staging_belt,
         }
     }
 
@@ -216,6 +213,7 @@ impl ShipRenderer {
         viewport_offset: i32,
         output_texture_view: &wgpu::TextureView,
         encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
     ) {
         // Update uniforms
         let uniform_values = ShipRendererUniforms {
@@ -225,15 +223,13 @@ impl ShipRenderer {
             viewport_height: game_params.viewport_height,
             viewport_offset,
         };
-        self.staging_belt
-            .write_buffer(
-                encoder,
-                &self.uniform_buffer.buffer,
-                0,
-                wgpu::BufferSize::new(self.uniform_buffer.size as _).unwrap(),
-            )
-            .copy_from_slice(bytemuck::bytes_of(&uniform_values));
-        self.staging_belt.finish();
+        belt.write_buffer(
+            encoder,
+            &self.uniform_buffer.buffer,
+            0,
+            wgpu::BufferSize::new(self.uniform_buffer.size as _).unwrap(),
+        )
+        .copy_from_slice(bytemuck::bytes_of(&uniform_values));
 
         let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: None,
@@ -257,10 +253,6 @@ impl ShipRenderer {
 
         rpass.set_pipeline(&self.outline_pipeline);
         rpass.draw(0..5_u32, 0..1);
-    }
-
-    pub fn after_queue_submission(&mut self) {
-        self.staging_belt.recall();
     }
 }
 
@@ -297,11 +289,19 @@ mod tests {
         let staging_buffer = gpu::create_readback_buffer(&device, TEST_W, TEST_H, 8);
 
         let mut renderer = ShipRenderer::init(&device);
+        let mut belt = wgpu::util::StagingBelt::new(device.clone(), 256);
 
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
         gpu::encode_clear_texture(&mut encoder, &target.view);
-        renderer.render(&state, &game_params, 0, &target.view, &mut encoder);
+        renderer.render(
+            &state,
+            &game_params,
+            0,
+            &target.view,
+            &mut encoder,
+            &mut belt,
+        );
         gpu::encode_texture_readback(
             &mut encoder,
             &target.texture,
@@ -310,8 +310,9 @@ mod tests {
             TEST_H,
             8,
         );
+        belt.finish();
         queue.submit(Some(encoder.finish()));
-        renderer.after_queue_submission();
+        belt.recall();
 
         let raw = gpu::readback_pixels(&device, &staging_buffer);
         let rgba = gpu::rgba16f_to_rgba8(&raw, TEST_W, TEST_H);


### PR DESCRIPTION
## Summary

- Removes 6 separate `wgpu::util::StagingBelt` fields spread across `particles.rs` (x2), `level_manager.rs` (x2), `render.rs`, and `ship.rs`
- Adds one shared belt to `Spout` with chunk size matching a terrain tile upload
- All `write_buffer` callers now take `belt: &mut wgpu::util::StagingBelt`; a single `finish()` fires before `queue.submit()` and a single `recall()` after
- Removes all `after_queue_submission()` methods that existed solely to call `recall()`
- Tests that exercise staging belt writes create a local belt directly

## Test plan

- [ ] `cargo build` clean
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test --verbose` — all 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)