### PR TITLE
macOS .app bundle packaging + release workflow

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,53 @@
+name: Release macOS
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            target/
+          key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-release-
+
+      - name: Build and package
+        run: ./scripts/package_macos.sh --dmg
+
+      - name: Verify .app exists
+        run: test -d target/release/Spout.app
+
+      - name: Upload .app bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: Spout-macOS
+          path: target/release/Spout.app
+
+      - name: Upload .dmg
+        uses: actions/upload-artifact@v4
+        with:
+          name: Spout-macOS-dmg
+          path: target/release/Spout.dmg
+
+      # Attach artifacts to GitHub Release when triggered by a version tag.
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/release/Spout.dmg
+          generate_release_notes: true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -26,11 +26,44 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-release-
 
+      # Import Developer ID certificate if secrets are configured.
+      - name: Import signing certificate
+        if: env.APPLE_CERTIFICATE != ''
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain-db
+          echo -n "$APPLE_CERTIFICATE" | base64 --decode -o "$CERT_PATH"
+          security create-keychain -p "" "$KEYCHAIN_PATH"
+          security set-keychain-settings "$KEYCHAIN_PATH"
+          security unlock-keychain -p "" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" \
+              -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
       - name: Build and package
         run: ./scripts/package_macos.sh --dmg
 
       - name: Verify .app exists
         run: test -d target/release/Spout.app
+
+      # Notarize if signing secrets are available.
+      - name: Notarize DMG
+        if: env.APPLE_ID != ''
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: HNRULUX5AH
+        run: |
+          xcrun notarytool submit target/release/Spout.dmg \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_ID_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait
+          xcrun stapler staple target/release/Spout.dmg
 
       - name: Upload .app bundle
         uses: actions/upload-artifact@v4
@@ -51,3 +84,11 @@ jobs:
         with:
           files: target/release/Spout.dmg
           generate_release_notes: true
+
+      # Clean up keychain.
+      - name: Clean up keychain
+        if: always()
+        run: |
+          if [ -f "$RUNNER_TEMP/build.keychain-db" ]; then
+            security delete-keychain "$RUNNER_TEMP/build.keychain-db" || true
+          fi

--- a/_context/macos-signing.md
+++ b/_context/macos-signing.md
@@ -1,54 +1,66 @@
 # macOS Code Signing & Notarization
 
-Currently using ad-hoc signing (`codesign -s -`). This works for local use
-but unsigned apps trigger Gatekeeper warnings for other users.
+**Team ID:** HNRULUX5AH
 
-## When an Apple Developer account is available
+## Local signing
 
-### Repository secrets needed
+`scripts/package_macos.sh` auto-detects a "Developer ID Application" identity
+in your keychain. If found, it signs with hardened runtime (required for
+notarization). Otherwise it falls back to ad-hoc signing.
+
+### Setup (one-time)
+
+1. Open Xcode → Settings → Accounts → Manage Certificates
+2. Create a "Developer ID Application" certificate
+3. It will be installed in your login keychain automatically
+4. Run `security find-identity -v -p codesigning` to verify it shows up
+
+### Local notarization
+
+After building a signed DMG:
+```bash
+xcrun notarytool submit target/release/Spout.dmg \
+    --apple-id YOUR_APPLE_ID \
+    --password YOUR_APP_SPECIFIC_PASSWORD \
+    --team-id HNRULUX5AH \
+    --wait
+
+xcrun stapler staple target/release/Spout.dmg
+```
+
+Generate an app-specific password at https://appleid.apple.com/account/manage
+
+## CI signing (GitHub Actions)
+
+The release workflow (`.github/workflows/release-macos.yml`) supports signing
+and notarization when the following repository secrets are configured:
+
+### Required secrets
 
 | Secret | Description |
 |--------|-------------|
 | `APPLE_CERTIFICATE` | Base64-encoded `.p12` Developer ID Application certificate |
-| `APPLE_CERTIFICATE_PASSWORD` | Password for the `.p12` file |
-| `APPLE_TEAM_ID` | 10-character Apple Developer Team ID |
+| `APPLE_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12` file |
 | `APPLE_ID` | Apple ID email for notarization |
-| `APPLE_ID_PASSWORD` | App-specific password (generate at appleid.apple.com) |
+| `APPLE_ID_PASSWORD` | App-specific password (not your Apple ID password) |
 
-### Signing steps (replace ad-hoc in `package_macos.sh`)
-
-```bash
-# Import certificate into a temporary keychain
-security create-keychain -p "" build.keychain
-security import "$CERTIFICATE_PATH" -k build.keychain -P "$PASSWORD" -T /usr/bin/codesign
-security set-key-partition-list -S apple-tool:,apple: -k "" build.keychain
-security list-keychains -d user -s build.keychain
-
-# Sign with Developer ID
-codesign --deep --force --verify --verbose \
-    --sign "Developer ID Application: Your Name ($TEAM_ID)" \
-    --options runtime \
-    "$BUNDLE_DIR"
-```
-
-### Notarization
+### Exporting the certificate
 
 ```bash
-# Submit for notarization
-xcrun notarytool submit "$DMG_PATH" \
-    --apple-id "$APPLE_ID" \
-    --password "$APPLE_ID_PASSWORD" \
-    --team-id "$TEAM_ID" \
-    --wait
+# Export from Keychain Access → My Certificates → Developer ID Application
+# Choose .p12 format, set a password
 
-# Staple the ticket
-xcrun stapler staple "$DMG_PATH"
+# Base64-encode for the GitHub secret:
+base64 -i DeveloperID.p12 | pbcopy
+# Paste into the APPLE_CERTIFICATE secret
 ```
 
-### CI workflow changes
+### How it works
 
-Update `.github/workflows/release-macos.yml` to:
-1. Decode and import the certificate from secrets
-2. Replace `codesign -s -` with the Developer ID signing command
-3. Add notarization step after DMG creation
-4. Clean up the temporary keychain
+1. CI imports the `.p12` into a temporary keychain
+2. `package_macos.sh` finds the Developer ID identity and signs with hardened runtime
+3. CI notarizes the DMG via `notarytool` and staples the ticket
+4. Temporary keychain is cleaned up
+
+Without secrets, the workflow still runs — it just produces an ad-hoc signed
+build (fine for testing, not distributable without Gatekeeper warnings).

--- a/_context/macos-signing.md
+++ b/_context/macos-signing.md
@@ -1,0 +1,54 @@
+# macOS Code Signing & Notarization
+
+Currently using ad-hoc signing (`codesign -s -`). This works for local use
+but unsigned apps trigger Gatekeeper warnings for other users.
+
+## When an Apple Developer account is available
+
+### Repository secrets needed
+
+| Secret | Description |
+|--------|-------------|
+| `APPLE_CERTIFICATE` | Base64-encoded `.p12` Developer ID Application certificate |
+| `APPLE_CERTIFICATE_PASSWORD` | Password for the `.p12` file |
+| `APPLE_TEAM_ID` | 10-character Apple Developer Team ID |
+| `APPLE_ID` | Apple ID email for notarization |
+| `APPLE_ID_PASSWORD` | App-specific password (generate at appleid.apple.com) |
+
+### Signing steps (replace ad-hoc in `package_macos.sh`)
+
+```bash
+# Import certificate into a temporary keychain
+security create-keychain -p "" build.keychain
+security import "$CERTIFICATE_PATH" -k build.keychain -P "$PASSWORD" -T /usr/bin/codesign
+security set-key-partition-list -S apple-tool:,apple: -k "" build.keychain
+security list-keychains -d user -s build.keychain
+
+# Sign with Developer ID
+codesign --deep --force --verify --verbose \
+    --sign "Developer ID Application: Your Name ($TEAM_ID)" \
+    --options runtime \
+    "$BUNDLE_DIR"
+```
+
+### Notarization
+
+```bash
+# Submit for notarization
+xcrun notarytool submit "$DMG_PATH" \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_ID_PASSWORD" \
+    --team-id "$TEAM_ID" \
+    --wait
+
+# Staple the ticket
+xcrun stapler staple "$DMG_PATH"
+```
+
+### CI workflow changes
+
+Update `.github/workflows/release-macos.yml` to:
+1. Decode and import the certificate from secrets
+2. Replace `codesign -s -` with the Developer ID signing command
+3. Add notarization step after DMG creation
+4. Clean up the temporary keychain

--- a/macos/Info.plist
+++ b/macos/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>Spout</string>
+    <key>CFBundleDisplayName</key>
+    <string>Spout</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.glalonde.spout</string>
+    <key>CFBundleVersion</key>
+    <string>0.1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>spout</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/package_macos.sh
+++ b/scripts/package_macos.sh
@@ -4,8 +4,19 @@
 # Optionally creates a .dmg disk image.
 #
 # Usage:
-#   ./scripts/package_macos.sh           # build + .app bundle
+#   ./scripts/package_macos.sh           # build + .app bundle (ad-hoc sign)
 #   ./scripts/package_macos.sh --dmg     # also create .dmg
+#
+# Code signing:
+#   The script looks for a "Developer ID Application" identity in the keychain.
+#   If found, it signs with that identity + hardened runtime (required for
+#   notarization). Otherwise it falls back to ad-hoc signing.
+#
+# Notarization (after signing with Developer ID):
+#   xcrun notarytool submit target/release/Spout.dmg \
+#       --apple-id YOUR_APPLE_ID --password APP_SPECIFIC_PASSWORD \
+#       --team-id HNRULUX5AH --wait
+#   xcrun stapler staple target/release/Spout.dmg
 #
 set -euo pipefail
 
@@ -34,9 +45,20 @@ if [ -f "$PROJECT_DIR/macos/AppIcon.icns" ]; then
     cp "$PROJECT_DIR/macos/AppIcon.icns" "$BUNDLE_DIR/Contents/Resources/AppIcon.icns"
 fi
 
-# Ad-hoc code sign (allows running without Gatekeeper issues locally)
-echo "==> Ad-hoc signing..."
-codesign --force --deep --sign - "$BUNDLE_DIR"
+# Code signing: use Developer ID if available, otherwise ad-hoc.
+SIGN_IDENTITY=""
+if security find-identity -v -p codesigning 2>/dev/null | grep -q "Developer ID Application"; then
+    SIGN_IDENTITY=$(security find-identity -v -p codesigning 2>/dev/null \
+        | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
+    echo "==> Signing with: $SIGN_IDENTITY"
+    codesign --force --deep --verify --verbose \
+        --sign "$SIGN_IDENTITY" \
+        --options runtime \
+        "$BUNDLE_DIR"
+else
+    echo "==> No Developer ID found — ad-hoc signing"
+    codesign --force --deep --sign - "$BUNDLE_DIR"
+fi
 
 echo "==> Bundle created at: $BUNDLE_DIR"
 
@@ -48,5 +70,11 @@ if [[ "${1:-}" == "--dmg" ]]; then
         -srcfolder "$BUNDLE_DIR" \
         -ov -format UDZO \
         "$DMG_PATH"
+
+    # Sign the DMG too if we have a Developer ID
+    if [ -n "$SIGN_IDENTITY" ]; then
+        codesign --force --sign "$SIGN_IDENTITY" "$DMG_PATH"
+    fi
+
     echo "==> DMG created at: $DMG_PATH"
 fi

--- a/scripts/package_macos.sh
+++ b/scripts/package_macos.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Build and package Spout as a macOS .app bundle.
+# Optionally creates a .dmg disk image.
+#
+# Usage:
+#   ./scripts/package_macos.sh           # build + .app bundle
+#   ./scripts/package_macos.sh --dmg     # also create .dmg
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_NAME="Spout"
+BUNDLE_DIR="$PROJECT_DIR/target/release/${APP_NAME}.app"
+DMG_PATH="$PROJECT_DIR/target/release/${APP_NAME}.dmg"
+
+echo "==> Building release binary..."
+cargo build --release --manifest-path "$PROJECT_DIR/Cargo.toml"
+
+echo "==> Creating ${APP_NAME}.app bundle..."
+rm -rf "$BUNDLE_DIR"
+mkdir -p "$BUNDLE_DIR/Contents/MacOS"
+mkdir -p "$BUNDLE_DIR/Contents/Resources"
+
+# Copy binary
+cp "$PROJECT_DIR/target/release/spout" "$BUNDLE_DIR/Contents/MacOS/spout"
+
+# Copy Info.plist
+cp "$PROJECT_DIR/macos/Info.plist" "$BUNDLE_DIR/Contents/Info.plist"
+
+# Copy icon if it exists
+if [ -f "$PROJECT_DIR/macos/AppIcon.icns" ]; then
+    cp "$PROJECT_DIR/macos/AppIcon.icns" "$BUNDLE_DIR/Contents/Resources/AppIcon.icns"
+fi
+
+# Ad-hoc code sign (allows running without Gatekeeper issues locally)
+echo "==> Ad-hoc signing..."
+codesign --force --deep --sign - "$BUNDLE_DIR"
+
+echo "==> Bundle created at: $BUNDLE_DIR"
+
+# Optionally create a .dmg
+if [[ "${1:-}" == "--dmg" ]]; then
+    echo "==> Creating DMG..."
+    rm -f "$DMG_PATH"
+    hdiutil create -volname "$APP_NAME" \
+        -srcfolder "$BUNDLE_DIR" \
+        -ov -format UDZO \
+        "$DMG_PATH"
+    echo "==> DMG created at: $DMG_PATH"
+fi


### PR DESCRIPTION
## Summary
- **`macos/Info.plist`**: bundle metadata — `com.glalonde.spout`, Metal GPU, macOS 13+, hi-DPI
- **`scripts/package_macos.sh`**: builds release binary, assembles `.app` bundle structure, ad-hoc code signs. Optional `--dmg` flag creates a disk image.
- **`.github/workflows/release-macos.yml`**: CI workflow triggered on version tags (`v*`) or manual dispatch. Builds, packages, uploads `.app` + `.dmg` as artifacts, attaches `.dmg` to GitHub Releases on tag push.
- **`_context/macos-signing.md`**: documents full code signing + notarization steps for when an Apple Developer account is available (secrets, codesign commands, notarytool, stapler).

All assets (`game_config.toml`, music, textures) are already embedded via `include_bytes!`/`include_str!` — no external resources needed in the bundle.

## Test plan
- [x] `scripts/package_macos.sh` produces a valid signed `.app` locally
- [ ] CI workflow runs successfully on `macos-latest` (will verify when merged/tagged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)