### PR TITLE
feat(input): triangle touch scheme for iOS rotation

### DIFF
--- a/_context/plans/active/near-term.md
+++ b/_context/plans/active/near-term.md
@@ -138,49 +138,49 @@ Steps:
 
 ---
 
-## 10. App Icon
+## 10. App Icon ✅
 
-All three platforms need a proper icon. Currently only `assets/spout_preview.png`
-exists (a gameplay screenshot, not a real icon).
+Done in PR #63. Source: in-game screenshot of ship (blue pixel-art triangle +
+fire thrust), cropped to 293×293.
 
-Design brief: the icon should evoke the game — a ship firing particles into
-terrain. Simple, bold, readable at small sizes. The particle glow/bloom
-aesthetic should translate to the icon.
-
-### macOS (.icns)
-- Source: 1024×1024 PNG → `iconutil` generates the `.icns`
-- Goes in `macos/` directory, referenced from `macos/Info.plist`
-- `scripts/package_macos.sh` copies it into the `.app` bundle
-- Sizes needed in the `.iconset`: 16, 32, 128, 256, 512 px (+ @2x variants)
-
-### iOS (asset catalog or individual PNGs)
-- Required sizes for iOS app icon: 60×60, 120×120, 180×180 px (iPhone)
-  and 76×76, 152×152, 167×167 px (iPad)
-- Plus 1024×1024 for App Store
-- Goes in `ios/` as an `AppIcon.appiconset` (Xcode asset catalog) or listed
-  in `Info.plist` under `CFBundleIcons`
-- Add `ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon` to Xcode build settings
-
-### Favicon (web / WASM)
-- 32×32 and 180×180 PNG (for apple-touch-icon) + `favicon.ico`
-- Goes in `web/` or wherever the gh-pages build drops static files
-
-### Suggested workflow
-1. Create master 1024×1024 artwork (Figma, Pixelmator, or procgen from game)
-2. Export PNGs → `scripts/generate_icons.sh` automates resizing with `sips`
-3. `iconutil --convert icns` for macOS
-4. Drop icon PNGs into iOS asset catalog
+- `macos/AppIcon.icns` — full iconset 16–1024px; picked up by `scripts/package_macos.sh`
+- `ios/Assets.xcassets/AppIcon.appiconset/` — all iPhone/iPad sizes + Contents.json;
+  Xcode project wired up with Resources build phase + `ASSETCATALOG_COMPILER_APPICON_NAME`
+- `wasm-resources/favicon.ico` + `favicon.png`; `index.template.html` updated with `<link rel="icon">`
 
 ---
 
-## 11. Virtual Joystick / Touch Visual Feedback
+## 11. Touch Controls — Visual Feedback & Layout Options
 
-Touch controls currently give no visual indication of where the thrust/rotate zones are or whether input is registered. A virtual joystick or translucent on-screen control overlay would make the iOS experience significantly more discoverable.
+Touch controls currently give no visual indication of where the thrust/rotate zones are or whether input is registered. The control layout should be configurable; at least two schemes are worth prototyping.
 
-Options to explore:
+### Option A: Triangle Split (implemented, try on device)
+
+The right half is divided by a diagonal from top-center `(W/2, 0)` to bottom-right `(W, H)`:
+- **Upper-right triangle** → rotate CW (`rotate = -1.0`)
+- **Lower-left triangle** → rotate CCW (`rotate = +1.0`)
+- Left half → thrust (unchanged)
+
+No dead zone. A single touch anywhere in the right half rotates; dragging across the diagonal switches direction instantly. Direction is computed from the current touch position, not where the touch started.
+
+CW condition: `y * (W/2) < H * (x - W/2)`
+
+Tasks:
+- [x] Implement triangle zone split in `input.rs` (`TouchControlScheme::Triangle`)
+- [x] Gate behind `touch_control_scheme = "triangle"` in `game_config.toml`
+- [ ] Draw a faint diagonal line indicator in the HUD (makes the split visible while learning)
+
+### Option B: Virtual Joystick
+
+A thumb origin + knob that tracks the touch, emits thrust in the joystick direction.
+
+Tasks:
 - [ ] Simple semi-transparent zone indicators (left = rotate, right = thrust) drawn as HUD overlay
-- [ ] Virtual joystick: a thumb origin + knob that tracks the touch, emits thrust in the joystick direction
+- [ ] Virtual joystick: thumb-origin + knob tracking touch position
 - [ ] Haptic feedback on thrust (iOS `UIImpactFeedbackGenerator`) — requires FFI or a winit hook
+
+### Config
+Both schemes should live behind `touch_control_scheme` in `game_config.toml` so they can be swapped without recompiling.
 
 ---
 

--- a/game_config.toml
+++ b/game_config.toml
@@ -6,6 +6,10 @@ level_height = 480
 fps = 60.0
 music_starts_on = false
 render_ship = true
+# Touch control layout on mobile.
+# "triangle" = right half split by diagonal (top-center→bottom-right): upper-right → CW, lower-left → CCW.
+# "drag" = original drag-to-aim scheme.
+touch_control_scheme = "triangle"
 
 [particle_system_params]
 emission_rate = 10000

--- a/src/game_params.rs
+++ b/src/game_params.rs
@@ -2,6 +2,20 @@
 
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TouchControlScheme {
+    /// Drag-to-aim: touching the right half and dragging sets an absolute target
+    /// heading via a bang-bang controller. Original scheme.
+    #[default]
+    Drag,
+    /// Triangle split: the right half is divided by a diagonal from top-center to
+    /// bottom-right. Current touch position determines direction — above/right of
+    /// the diagonal → rotate CW, below/left → rotate CCW. Drag across the diagonal
+    /// to switch directions instantly, no dead zone.
+    Triangle,
+}
+
 // Parameters that define the game. These don't change at runtime.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
 pub struct GameParams {
@@ -13,6 +27,9 @@ pub struct GameParams {
     pub fps: f64,
     pub music_starts_on: bool,
     pub render_ship: bool,
+
+    #[serde(default)]
+    pub touch_control_scheme: TouchControlScheme,
 
     #[serde(default)]
     pub particle_system_params: ParticleSystemParams,
@@ -159,6 +176,7 @@ impl Default for GameParams {
             fps: 60.0,
             music_starts_on: false,
             render_ship: false,
+            touch_control_scheme: TouchControlScheme::Drag,
             particle_system_params: ParticleSystemParams::default(),
             ship_params: ShipParams::default(),
             level_params: LevelParams::default(),
@@ -223,6 +241,7 @@ mod tests {
             fps: 60.0,
             music_starts_on: false,
             render_ship: true,
+            touch_control_scheme: TouchControlScheme::Drag,
             particle_system_params: ParticleSystemParams::default(),
             ship_params: ShipParams::default(),
             level_params: LevelParams::default(),

--- a/src/input.rs
+++ b/src/input.rs
@@ -333,7 +333,6 @@ mod tests {
 /// Also used to detect "taps" (touchend with displacement below this threshold).
 const MIN_DRAG_PX: f32 = 8.0;
 
-
 /// Converts a 2-D touch drag into an absolute target heading in radians.
 ///
 /// Returns `None` when the drag is too small to reliably determine a direction
@@ -837,8 +836,7 @@ impl InputCollector {
                 match self.touch_scheme {
                     TouchControlScheme::Triangle => {
                         let rx = s.rotate_x - s.canvas_width / 2.0;
-                        let is_cw =
-                            s.rotate_y * (s.canvas_width / 2.0) < s.canvas_height * rx;
+                        let is_cw = s.rotate_y * (s.canvas_width / 2.0) < s.canvas_height * rx;
                         let rot = if is_cw { -1.0_f32 } else { 1.0_f32 };
                         (true, None, rot)
                     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -388,19 +388,21 @@ pub struct InputState {
 //
 // Screen is split vertically at center (landscape orientation assumed):
 //   Left half  → thrust zone: any touch here fires the thruster.
-//   Right half → rotate zone: horizontal position within the half controls
-//                rotation rate (left edge of half = full CCW, right = full CW,
-//                center of half = 0 with a small deadzone).
+//   Right half → rotate zone (scheme-dependent, see TouchControlScheme):
+//     Drag:     drag from anchor sets an absolute target heading.
+//     Triangle: diagonal from (W/2,0)→(W,H) splits CW (upper-right) from
+//               CCW (lower-left); direction follows current touch position.
 //
-// Two simultaneous touches (one per zone) are supported so rotation and thrust
-// are fully independent.
+// Two simultaneous touches (one per zone) are supported so rotation and
+// thrust are fully independent.
 // ------------------------------------------------------------------------
 
 /// Touch state shared between JS event listeners and the game loop (WASM only).
 #[cfg(target_arch = "wasm32")]
 #[derive(Default)]
 struct WasmTouch {
-    canvas_width: f32, // CSS px, refreshed each event
+    canvas_width: f32,  // CSS px, refreshed each event
+    canvas_height: f32, // CSS px, refreshed each event
     thrust_id: Option<i32>,
     rotate_id: Option<i32>,
     rotate_anchor_x: f32, // x at touchstart
@@ -543,12 +545,14 @@ impl InputCollector {
             let cb = Closure::<dyn FnMut(_)>::new(move |event: web_sys::TouchEvent| {
                 event.prevent_default();
                 let canvas_width = canvas_ref.client_width() as f32;
-                if canvas_width <= 0.0 {
+                let canvas_height = canvas_ref.client_height() as f32;
+                if canvas_width <= 0.0 || canvas_height <= 0.0 {
                     return;
                 }
                 let center = canvas_width / 2.0;
                 let mut s = state.borrow_mut();
                 s.canvas_width = canvas_width;
+                s.canvas_height = canvas_height;
                 let changed = event.changed_touches();
                 for i in 0..changed.length() {
                     if let Some(touch) = changed.get(i) {
@@ -829,23 +833,32 @@ impl InputCollector {
         let (touch_thrust, touch_has_rotate, touch_heading, touch_rotate) = {
             let s = self.wasm_touch.borrow();
             let thrust = s.thrust_id.is_some();
-            let (has_rotate, heading) = if s.rotate_id.is_some() {
-                // Touch drag takes highest priority.
-                let h = touch_delta_to_target_heading(
-                    s.rotate_anchor_x,
-                    s.rotate_anchor_y,
-                    s.rotate_x,
-                    s.rotate_y,
-                );
-                (true, h)
+            let (has_rotate, heading, rotate) = if s.rotate_id.is_some() {
+                match self.touch_scheme {
+                    TouchControlScheme::Triangle => {
+                        let rx = s.rotate_x - s.canvas_width / 2.0;
+                        let is_cw =
+                            s.rotate_y * (s.canvas_width / 2.0) < s.canvas_height * rx;
+                        let rot = if is_cw { -1.0_f32 } else { 1.0_f32 };
+                        (true, None, rot)
+                    }
+                    TouchControlScheme::Drag => {
+                        let h = touch_delta_to_target_heading(
+                            s.rotate_anchor_x,
+                            s.rotate_anchor_y,
+                            s.rotate_x,
+                            s.rotate_y,
+                        );
+                        (true, h, 0.0_f32)
+                    }
+                }
             } else if s.accel_heading.is_some() {
-                // Accelerometer provides heading when no rotate touch is active.
-                (true, s.accel_heading)
+                // Accelerometer provides heading when no rotate touch is active (drag only).
+                (true, s.accel_heading, 0.0_f32)
             } else {
-                (false, None)
+                (false, None, 0.0_f32)
             };
-            // WASM always uses the drag scheme for now.
-            (thrust, has_rotate, heading, 0.0_f32)
+            (thrust, has_rotate, heading, rotate)
         };
 
         // Touch owns its axis entirely; keyboard fills the other.

--- a/src/input.rs
+++ b/src/input.rs
@@ -2,6 +2,8 @@
 //! Supports desktop (winit keyboard events), mobile web (touch + DeviceOrientation),
 //! and absolute-angle heading via bang-bang controller.
 
+use crate::game_params::TouchControlScheme;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,11 +235,104 @@ mod tests {
         assert_eq!(state.thrust, 1.0);
         assert_eq!(state.rotate, 1.0);
     }
+
+    // --- triangle scheme (non-WASM only) --------------------------------------
+    //
+    // surface: 400×300. center_x=200. Diagonal from (200,0) to (400,300).
+    // CW condition: y * 200 < 300 * (x - 200)
+    //
+    // Upper-right triangle (CW): e.g. (380, 10) → 10*200=2000 < 300*180=54000 ✓
+    // Lower-left triangle (CCW): e.g. (210, 280) → 280*200=56000 ≥ 300*10=3000 ✓
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn triangle_collector() -> InputCollector {
+        let mut c = InputCollector::default();
+        c.surface_width = 400.0;
+        c.surface_height = 300.0;
+        c.touch_scheme = TouchControlScheme::Triangle;
+        c
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn set_right_touch(c: &mut InputCollector, x: f32, y: f32) {
+        c.rotate_id = Some(1);
+        c.rotate_x = x;
+        c.rotate_y = y;
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn triangle_upper_right_is_cw() {
+        // Upper-right area → CW → rotate = -1.0, no target heading.
+        let mut c = triangle_collector();
+        set_right_touch(&mut c, 380.0, 10.0);
+        let state = c.current_state();
+        assert_eq!(state.rotate, -1.0);
+        assert_eq!(state.target_heading, None);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn triangle_lower_left_is_ccw() {
+        // Lower-left area of right half → CCW → rotate = +1.0.
+        let mut c = triangle_collector();
+        set_right_touch(&mut c, 210.0, 280.0);
+        let state = c.current_state();
+        assert_eq!(state.rotate, 1.0);
+        assert_eq!(state.target_heading, None);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn triangle_drag_across_diagonal_switches_direction() {
+        // Same touch ID; moving from CW zone to CCW zone updates rotate.
+        let mut c = triangle_collector();
+        set_right_touch(&mut c, 380.0, 10.0); // CW
+        assert_eq!(c.current_state().rotate, -1.0);
+        c.rotate_x = 210.0;
+        c.rotate_y = 280.0; // moved to CCW zone
+        assert_eq!(c.current_state().rotate, 1.0);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn triangle_suppresses_keyboard_when_active() {
+        // Any right-half touch suppresses keyboard rotation.
+        let mut c = triangle_collector();
+        set_right_touch(&mut c, 380.0, 10.0);
+        c.held_left = true;
+        let state = c.current_state();
+        assert_eq!(state.rotate, -1.0); // triangle wins, not keyboard
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn triangle_thrust_independent() {
+        // Left-half thrust + right-half CW touch → both active simultaneously.
+        let mut c = triangle_collector();
+        c.thrust_id = Some(1);
+        set_right_touch(&mut c, 380.0, 10.0);
+        c.rotate_id = Some(2); // override id set by set_right_touch
+        let state = c.current_state();
+        assert_eq!(state.thrust, 1.0);
+        assert_eq!(state.rotate, -1.0);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn triangle_no_touch_no_rotate() {
+        // No right-half touch → no rotation, keyboard applies.
+        let mut c = triangle_collector();
+        c.held_left = true;
+        let state = c.current_state();
+        assert_eq!(state.rotate, 1.0); // keyboard
+    }
 }
 
 /// Minimum drag distance (px) before a touch heading is committed.
 /// Also used to detect "taps" (touchend with displacement below this threshold).
 const MIN_DRAG_PX: f32 = 8.0;
+
 
 /// Converts a 2-D touch drag into an absolute target heading in radians.
 ///
@@ -345,6 +440,8 @@ pub struct InputCollector {
     held_cam_perspective: bool,
     held_cam_reset: bool,
 
+    touch_scheme: TouchControlScheme,
+
     // Native touch (updated via winit WindowEvent::Touch; IDs are winit's u64).
     // surface_width/height (physical px) must be kept current via set_surface_width/height().
     #[cfg(not(target_arch = "wasm32"))]
@@ -353,12 +450,13 @@ pub struct InputCollector {
     surface_height: f32,
     #[cfg(not(target_arch = "wasm32"))]
     thrust_id: Option<u64>,
+    // Right-half touch (drag scheme: drag sets heading; triangle scheme: position vs diagonal).
     #[cfg(not(target_arch = "wasm32"))]
     rotate_id: Option<u64>,
     #[cfg(not(target_arch = "wasm32"))]
-    rotate_anchor_x: f32, // x at touchstart
+    rotate_anchor_x: f32, // x at touchstart (drag scheme only)
     #[cfg(not(target_arch = "wasm32"))]
-    rotate_anchor_y: f32, // y at touchstart
+    rotate_anchor_y: f32, // y at touchstart (drag scheme only)
     #[cfg(not(target_arch = "wasm32"))]
     rotate_x: f32, // x at latest touchmove/touchstart
     #[cfg(not(target_arch = "wasm32"))]
@@ -386,6 +484,7 @@ impl Default for InputCollector {
             held_cam_right: false,
             held_cam_perspective: false,
             held_cam_reset: false,
+            touch_scheme: TouchControlScheme::Drag,
             #[cfg(not(target_arch = "wasm32"))]
             surface_width: 0.0,
             #[cfg(not(target_arch = "wasm32"))]
@@ -421,6 +520,10 @@ impl InputCollector {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn set_surface_height(&mut self, height: f32) {
         self.surface_height = height;
+    }
+
+    pub fn set_touch_scheme(&mut self, scheme: TouchControlScheme) {
+        self.touch_scheme = scheme;
     }
 
     /// Register DOM touch event listeners on the game canvas (WASM only).
@@ -639,9 +742,9 @@ impl InputCollector {
             use winit::event::TouchPhase;
             let center = self.surface_width / 2.0;
             let x = touch.location.x as f32;
+            let y = touch.location.y as f32;
             match touch.phase {
                 TouchPhase::Started => {
-                    let y = touch.location.y as f32;
                     if x < center {
                         if self.thrust_id.is_none() {
                             self.thrust_id = Some(touch.id);
@@ -655,9 +758,10 @@ impl InputCollector {
                     }
                 }
                 TouchPhase::Moved => {
+                    // Only the drag scheme tracks position after touch-down.
                     if Some(touch.id) == self.rotate_id {
                         self.rotate_x = x;
-                        self.rotate_y = touch.location.y as f32;
+                        self.rotate_y = y;
                     }
                 }
                 TouchPhase::Ended | TouchPhase::Cancelled => {
@@ -684,25 +788,45 @@ impl InputCollector {
             _ => 0.0,
         };
 
+        // touch_rotate: digital rotate value produced by touch (±1.0 for bezel, 0.0 for drag).
+        // touch_heading: absolute target heading produced by touch (drag scheme only).
         #[cfg(not(target_arch = "wasm32"))]
-        let (touch_thrust, touch_has_rotate, touch_heading) = {
+        let (touch_thrust, touch_has_rotate, touch_heading, touch_rotate) = {
             let thrust = self.thrust_id.is_some();
-            let (has_rotate, heading) = if self.rotate_id.is_some() {
-                let h = touch_delta_to_target_heading(
-                    self.rotate_anchor_x,
-                    self.rotate_anchor_y,
-                    self.rotate_x,
-                    self.rotate_y,
-                );
-                (true, h)
-            } else {
-                (false, None)
+            let (has_rotate, heading, rotate) = match self.touch_scheme {
+                TouchControlScheme::Drag => {
+                    if self.rotate_id.is_some() {
+                        let h = touch_delta_to_target_heading(
+                            self.rotate_anchor_x,
+                            self.rotate_anchor_y,
+                            self.rotate_x,
+                            self.rotate_y,
+                        );
+                        (true, h, 0.0_f32)
+                    } else {
+                        (false, None, 0.0_f32)
+                    }
+                }
+                TouchControlScheme::Triangle => {
+                    if self.rotate_id.is_some() {
+                        // Diagonal from (W/2, 0) to (W, H) splits the right half.
+                        // A point is CW (upper-right triangle) when:
+                        //   y * (W/2) < H * (x - W/2)
+                        let rx = self.rotate_x - self.surface_width / 2.0;
+                        let is_cw =
+                            self.rotate_y * (self.surface_width / 2.0) < self.surface_height * rx;
+                        let rot = if is_cw { -1.0_f32 } else { 1.0_f32 };
+                        (true, None, rot)
+                    } else {
+                        (false, None, 0.0_f32)
+                    }
+                }
             };
-            (thrust, has_rotate, heading)
+            (thrust, has_rotate, heading, rotate)
         };
 
         #[cfg(target_arch = "wasm32")]
-        let (touch_thrust, touch_has_rotate, touch_heading) = {
+        let (touch_thrust, touch_has_rotate, touch_heading, touch_rotate) = {
             let s = self.wasm_touch.borrow();
             let thrust = s.thrust_id.is_some();
             let (has_rotate, heading) = if s.rotate_id.is_some() {
@@ -720,15 +844,17 @@ impl InputCollector {
             } else {
                 (false, None)
             };
-            (thrust, has_rotate, heading)
+            // WASM always uses the drag scheme for now.
+            (thrust, has_rotate, heading, 0.0_f32)
         };
 
         // Touch owns its axis entirely; keyboard fills the other.
         let thrust = if touch_thrust { 1.0 } else { keyboard_thrust };
-        // When touch is in the rotate zone (even within the drag deadzone), it
-        // suppresses keyboard rotation so the two don't fight.
+        // When touch is in the rotate zone it suppresses keyboard rotation.
+        // For drag scheme touch_rotate=0.0 and target_heading drives rotation.
+        // For bezel scheme touch_rotate=±1.0 and target_heading is None.
         let rotate = if touch_has_rotate {
-            0.0
+            touch_rotate
         } else {
             keyboard_rotate
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -464,6 +464,7 @@ impl framework::Example for Spout {
         };
 
         let mut collector = InputCollector::default();
+        collector.set_touch_scheme(game_params.touch_control_scheme);
 
         #[cfg(not(target_arch = "wasm32"))]
         {


### PR DESCRIPTION
## Summary

- Adds `TouchControlScheme::Triangle` (new enum in `game_params.rs`): the right half of the screen is split by a diagonal from top-center `(W/2, 0)` to bottom-right `(W, H)`
  - Upper-right triangle → rotate CW
  - Lower-left triangle → rotate CCW
- Direction is read from the **current touch position** each frame — dragging across the diagonal switches direction instantly, no dead zone, no anchor
- Left half → thrust (unchanged from before)
- Gated behind `touch_control_scheme = "triangle"` in `game_config.toml`; original drag-to-aim scheme available as `"drag"`
- `InputCollector::set_touch_scheme()` applies the config at init; WASM path is unchanged (still drag)

## Test plan

- [ ] All 69 existing tests pass (`cargo test`)
- [ ] On iOS device: right thumb on right half rotates ship; sliding across the diagonal switches CW↔CCW
- [ ] Left half still thrusts; thrust + rotation simultaneously works
- [ ] `touch_control_scheme = "drag"` in `game_config.toml` restores original behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)