### PR TITLE
Game over on falling out of viewport; track visible side walls

### DIFF
--- a/_context/plans/active/near-term.md
+++ b/_context/plans/active/near-term.md
@@ -343,6 +343,38 @@ Tasks:
 
 ---
 
+## 21. Visible Indestructible Side Walls
+
+Today the leftmost and rightmost terrain columns hold max-health cells
+(§8a) and a secondary bounds check kills the ship if it crosses the level
+edge. Both are correct but visually subtle — the player may not realise
+*why* they died, since the boundary looks like ordinary terrain that
+could (in principle) be eroded.
+
+The fix is to make the side walls *look* unkillable: a clear visual
+distinction (e.g. a brighter colour, a hatched/striped pattern, a glowing
+edge) that signals "you cannot break through here." Combined with the
+existing kill behaviour, the player should immediately understand what
+happens when the ship crosses that line.
+
+Tasks:
+- [ ] Decide visual treatment: distinct colour vs. pattern vs. animated
+      glow. Should be readable at the small game-view resolution and not
+      compete with the bloom-driven neon palette.
+- [ ] Render path: probably a separate render pass / shader override on
+      the leftmost+rightmost N columns, drawn after terrain so it always
+      wins. Alternative: terrain shader detects max-health cells and
+      colours them differently (cheaper but couples wall colour to "max
+      health" semantics).
+- [ ] Width: one column is enough to kill the ship but may be too thin to
+      read visually; consider 2–3 columns wide so the wall is unmistakable.
+- [ ] Confirm the wall reads correctly at native iPhone resolution after
+      the upscale (no aliasing into invisibility, no shimmer).
+- [ ] Optional: small particle/spark effect when the ship is destroyed by
+      hitting the wall, to reinforce the cause of death.
+
+---
+
 ## Branch Audit Remainder
 
 The `legacy_wgpu` branch has been audited (see `legacy-port-inventory.md`). These branches have not yet been reviewed:

--- a/_context/plans/active/near-term.md
+++ b/_context/plans/active/near-term.md
@@ -257,8 +257,9 @@ visible window. When that happens, declare game over rather than letting
 the player chase an offscreen ship.
 
 Tasks:
-- [ ] Define drop threshold (e.g. `ship.pos.y < viewport_offset - viewport_height`)
-- [ ] Trigger death + game over when crossed
+- [x] Define drop threshold (`ship.pos.y < viewport_offset - viewport_height`)
+- [x] Trigger death + game over when crossed (in `update_ship`, alongside the
+      existing horizontal-edge check)
 - [ ] Visual cue as the ship nears the threshold (the offscreen-ship
       indicator in `longterm-features.md` complements this)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,6 +286,18 @@ impl Spout {
             self.state.dead = true;
             self.state.explosion_pending = true;
         }
+
+        // Kill the ship if it falls more than one viewport-height below the
+        // bottom of the visible window. At default gravity (40 game units/s²)
+        // and viewport_height 160, that is ~2.8 s of free-fall from rest from
+        // the viewport bottom — enough to recover from a stall, but not from
+        // a sustained fall.
+        let bottom = self.state.viewport_offset as f32;
+        let viewport_h = self.game_params.viewport_height as f32;
+        if self.state.ship_state.position[1] < bottom - viewport_h {
+            self.state.dead = true;
+            self.state.explosion_pending = true;
+        }
     }
 
     fn title_emitter_motion(&self) -> particles::EmitterMotion {


### PR DESCRIPTION
## Summary

- **Commit 1** — Adds a vertical-fall game over: the ship dies if `pos.y < viewport_offset - viewport_height`, mirroring the existing horizontal-edge kill. At default gravity (40 game units/s²) and viewport_height 160, that's ~2.8 s of free-fall from rest from the viewport bottom — long enough to recover from a stall, short enough that a sustained fall ends the run. Marks §17 (\"Drop-Below-Viewport Game Over\") tasks done in `_context/plans/active/near-term.md`.
- **Commit 2** — Adds §21 (\"Visible Indestructible Side Walls\") to the near-term plan: the leftmost/rightmost columns already kill the ship via the §8a boundary work, but they look like ordinary terrain. Captures the follow-up to make those walls visually unmistakable so the cause of death is clear.

## Test plan

- [x] Native: stall the ship with thrust off and confirm it falls a bit further than one viewport-height below the visible window before the explosion fires
- [x] Native: brief stall + recovery should not trigger death
- [x] iOS device: same as native
- [x] Confirm explosion + GAME OVER overlay + tap-to-restart all still work when the kill is triggered by the new vertical check
- [ ] Side walls task description (§21) reads cleanly in `_context/plans/active/near-term.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)