### PR TITLE
Touch-zone diagonal hint for Triangle control scheme

### DIFF
--- a/_context/plans/active/near-term.md
+++ b/_context/plans/active/near-term.md
@@ -168,7 +168,10 @@ CW condition: `y * (W/2) < H * (x - W/2)`
 Tasks:
 - [x] Implement triangle zone split in `input.rs` (`TouchControlScheme::Triangle`)
 - [x] Gate behind `touch_control_scheme = "triangle"` in `game_config.toml`
-- [ ] Draw a faint diagonal line indicator in the HUD (makes the split visible while learning)
+- [x] Draw a faint diagonal line indicator in the HUD (makes the split visible
+      while learning) — `touch_zone_indicator.rs` renders an alpha-blended
+      thin line on the surface after composite, only when scheme is Triangle
+      and game is in Playing mode
 
 ### Option B: Virtual Joystick
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -394,6 +394,10 @@ struct TouchTracker {
     rotate_x: f32,
     rotate_y: f32,
     touch_started: bool,
+    /// Sticky "any touch event has occurred this session" flag — used to
+    /// detect that the player is on a touch device so we can show the
+    /// touch-zone hint. Never resets after the first touch.
+    ever_touched: bool,
 }
 
 impl TouchTracker {
@@ -407,6 +411,7 @@ impl TouchTracker {
 
     fn started(&mut self, id: TouchId, x: f32, y: f32) {
         self.touch_started = true;
+        self.ever_touched = true;
         if self.surface_width <= 0.0 || self.surface_height <= 0.0 {
             return;
         }
@@ -563,6 +568,20 @@ impl InputCollector {
 
     pub fn set_touch_scheme(&mut self, scheme: TouchControlScheme) {
         self.touch_scheme = scheme;
+    }
+
+    /// True once any touch event has been observed this session. Used by the
+    /// renderer to gate touch-only HUD elements so they don't appear on
+    /// keyboard-driven desktop or web sessions.
+    pub fn has_been_touched(&self) -> bool {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.touch.ever_touched
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.wasm_touch.borrow().ever_touched
+        }
     }
 
     /// Register DOM touch event listeners on the game canvas (WASM only).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,4 @@ pub mod shader_util;
 pub mod ship;
 pub mod text;
 pub mod textured_quad;
+pub mod touch_zone_indicator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use spout::particles;
 use spout::render;
 use spout::ship;
 use spout::text;
+use spout::touch_zone_indicator;
 
 /// Shortest signed angular distance from `current` to `target`, in [-π, π].
 fn angle_diff(target: f32, current: f32) -> f32 {
@@ -123,6 +124,7 @@ struct Spout {
     game_text: text::TextRenderer,
     audio: audio::AudioPlayer,
     staging_belt: wgpu::util::StagingBelt,
+    touch_zone_indicator: touch_zone_indicator::TouchZoneIndicator,
     /// Debug overlay: FPS counter rendered at display resolution. Debug builds only.
     #[cfg(debug_assertions)]
     overlay_text: text::TextRenderer,
@@ -527,6 +529,14 @@ impl framework::Example for Spout {
             audio::AudioPlayer::disabled()
         };
 
+        let touch_zone_indicator = touch_zone_indicator::TouchZoneIndicator::new(
+            device,
+            queue,
+            config.format,
+            config.width,
+            config.height,
+        );
+
         let mut collector = InputCollector::default();
         collector.set_touch_scheme(game_params.touch_control_scheme);
 
@@ -562,6 +572,7 @@ impl framework::Example for Spout {
             game_text,
             audio,
             staging_belt,
+            touch_zone_indicator,
             #[cfg(debug_assertions)]
             overlay_text,
             frame_times: Vec::with_capacity(60),
@@ -605,10 +616,6 @@ impl framework::Example for Spout {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
     ) {
-        // queue is only used by the debug overlay; suppress warning in release builds.
-        #[cfg(not(debug_assertions))]
-        let _ = queue;
-
         #[cfg(not(target_arch = "wasm32"))]
         {
             self.collector.set_surface_width(config.width as f32);
@@ -626,6 +633,8 @@ impl framework::Example for Spout {
         self.renderer
             .resize(config, device, &new_upscaled, self.bloom.bloom_view());
         self.upscaled_view = new_upscaled;
+        self.touch_zone_indicator
+            .resize(queue, config.width, config.height);
         #[cfg(debug_assertions)]
         self.overlay_text.resize(queue, config.width, config.height);
     }
@@ -810,6 +819,21 @@ impl framework::Example for Spout {
 
         // Composite upscaled HDR + bloom → surface (LDR).
         self.renderer.render(view, &mut encoder);
+
+        // Touch-zone diagonal hint. Only render if:
+        //   - Triangle scheme is active,
+        //   - the player has actually used touch this session (so it stays
+        //     hidden on keyboard-driven desktop and web), and
+        //   - we are in active gameplay (not title or game-over).
+        if matches!(
+            self.game_params.touch_control_scheme,
+            game_params::TouchControlScheme::Triangle
+        ) && self.collector.has_been_touched()
+            && self.state.mode == GameMode::Playing
+        {
+            self.touch_zone_indicator.render(view, &mut encoder);
+        }
+
         self.level_manager.decompose_tiles(&mut encoder);
 
         // Frame timing — collected in all build profiles.

--- a/src/shaders/touch_zone_indicator.wgsl
+++ b/src/shaders/touch_zone_indicator.wgsl
@@ -1,0 +1,78 @@
+// Faint diagonal line for the Triangle touch-control scheme.
+//
+// Renders a thin rectangle along the diagonal from screen-space (W/2, 0) to
+// (W, H) — the line that splits the right-half rotate zones into CW (above)
+// and CCW (below). The intent is a barely-visible hint while the player
+// learns the scheme; it should not compete with gameplay visuals.
+//
+// The line is opaque near the bottom-right corner where the diagonal meets
+// the screen edge, and fades to nothing as it climbs toward the top-center
+// start — so only the bottom portion of the diagonal is drawn, enough to
+// suggest the boundary without cutting across the whole screen.
+//
+// Drawn after the composite pass directly onto the surface. Uses alpha
+// blending; alpha is small so the line reads as a faint glow rather than a
+// hard divider.
+
+struct Uniforms {
+    surface_size: vec2<f32>, // pixels
+    thickness_px: f32,
+    _pad: f32,
+};
+
+@group(0) @binding(0) var<uniform> u: Uniforms;
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    // Distance along the diagonal, 0.0 at the top-center start, 1.0 at the
+    // bottom-right end. Used by the fragment shader to fade out.
+    @location(0) along: f32,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
+    // Endpoints in screen-pixel space (origin top-left, y down).
+    let start = vec2<f32>(u.surface_size.x * 0.5, 0.0);
+    let end = vec2<f32>(u.surface_size.x, u.surface_size.y);
+
+    let dir = normalize(end - start);
+    let perp = vec2<f32>(-dir.y, dir.x);
+    let half_thick = perp * (u.thickness_px * 0.5);
+
+    // Triangle strip: 4 vertices forming a thin rectangle along the diagonal.
+    // Vertices 0,1 sit at the start (along=0), 2,3 sit at the end (along=1).
+    var pos: vec2<f32>;
+    var along: f32;
+    if vi == 0u {
+        pos = start - half_thick;
+        along = 0.0;
+    } else if vi == 1u {
+        pos = start + half_thick;
+        along = 0.0;
+    } else if vi == 2u {
+        pos = end - half_thick;
+        along = 1.0;
+    } else {
+        pos = end + half_thick;
+        along = 1.0;
+    }
+
+    // Pixel space → NDC. Y-axis is flipped (screen y down → NDC y up).
+    let ndc = vec2<f32>(
+        pos.x / u.surface_size.x * 2.0 - 1.0,
+        -(pos.y / u.surface_size.y * 2.0 - 1.0),
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(ndc, 0.0, 1.0);
+    out.along = along;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Faintly visible at the bottom-right end of the line (along = 1.0);
+    // eased to invisible by ~1/3 of the way up the diagonal (along ≈ 0.67).
+    let peak_alpha: f32 = 0.4;
+    let fade = smoothstep(0.67, 1.0, in.along);
+    return vec4<f32>(1.0, 0.95, 0.85, peak_alpha * fade);
+}

--- a/src/touch_zone_indicator.rs
+++ b/src/touch_zone_indicator.rs
@@ -1,0 +1,150 @@
+//! Faint diagonal hint line for the Triangle touch-control scheme.
+//!
+//! Drawn after the bloom composite, directly onto the surface, only when the
+//! Triangle scheme is active and the game is in `Playing` mode. Renders as a
+//! thin alpha-blended rectangle — visible enough to teach the player where
+//! the CW/CCW split is, faint enough to not compete with the game.
+
+use wgpu::util::DeviceExt;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct Uniforms {
+    surface_size: [f32; 2],
+    thickness_px: f32,
+    _pad: f32,
+}
+
+pub struct TouchZoneIndicator {
+    pipeline: wgpu::RenderPipeline,
+    bind_group: wgpu::BindGroup,
+    uniform_buf: wgpu::Buffer,
+}
+
+impl TouchZoneIndicator {
+    /// Line thickness in surface pixels. Small enough to read as a hint, not
+    /// a UI element.
+    const THICKNESS_PX: f32 = 2.0;
+
+    pub fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        surface_format: wgpu::TextureFormat,
+        width: u32,
+        height: u32,
+    ) -> Self {
+        let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("touch_zone_indicator_uniform"),
+            contents: bytemuck::bytes_of(&Uniforms {
+                surface_size: [width as f32, height as f32],
+                thickness_px: Self::THICKNESS_PX,
+                _pad: 0.0,
+            }),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        let _ = queue;
+
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("touch_zone_indicator_bgl"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<Uniforms>() as u64),
+                },
+                count: None,
+            }],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("touch_zone_indicator_bg"),
+            layout: &bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buf.as_entire_binding(),
+            }],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("touch_zone_indicator_shader"),
+            source: wgpu::ShaderSource::Wgsl(crate::include_shader!("touch_zone_indicator.wgsl")),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("touch_zone_indicator_layout"),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+
+        let blend = wgpu::BlendState::ALPHA_BLENDING;
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("touch_zone_indicator"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(blend),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            cache: None,
+            multiview_mask: None,
+        });
+
+        TouchZoneIndicator {
+            pipeline,
+            bind_group,
+            uniform_buf,
+        }
+    }
+
+    pub fn resize(&self, queue: &wgpu::Queue, width: u32, height: u32) {
+        queue.write_buffer(
+            &self.uniform_buf,
+            0,
+            bytemuck::bytes_of(&Uniforms {
+                surface_size: [width as f32, height as f32],
+                thickness_px: Self::THICKNESS_PX,
+                _pad: 0.0,
+            }),
+        );
+    }
+
+    /// Append the indicator render pass to `encoder`. Loads the existing
+    /// surface contents and alpha-blends the line on top.
+    pub fn render(&self, view: &wgpu::TextureView, encoder: &mut wgpu::CommandEncoder) {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("touch_zone_indicator"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            ..Default::default()
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &self.bind_group, &[]);
+        pass.draw(0..4, 0..1);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a visual hint for the Triangle touch-control scheme's CW/CCW divider. A faint warm-white glow runs along the diagonal from the bottom-right corner up toward the top-center start, fading to invisible about a third of the way up. Without the hint, the boundary between rotate-CW (above the line) and rotate-CCW (below) was discoverable only by feel.

## Behavior

The hint is only drawn when **all three** are true:

- `touch_control_scheme = \"triangle\"` is configured.
- A touch event has occurred this session — keyboard-driven desktop and web sessions never see it.
- The game is in `GameMode::Playing` (not title or game-over).

## Implementation notes

- New `touch_zone_indicator` module: one render pipeline, 4-vertex triangle strip, alpha-blended onto the surface after the bloom composite. Uniform carries surface size + thickness; resize plumbing in `Spout::resize` keeps it in sync with the surface.
- WGSL shader builds the rectangle in pixel space and passes a `along` varying (0 at top-center start, 1 at bottom-right end). Fragment shader: `alpha = peak_alpha * smoothstep(0.67, 1.0, along)` with `peak_alpha = 0.4` — knobs to tweak if it's still too strong / too soft.
- Sticky `ever_touched: bool` added to `TouchTracker`, set on every `started()`. Exposed via `InputCollector::has_been_touched()` for the render gate.
- `_context/plans/active/near-term.md` §11 third task marked done in the same commit.

## Test plan

- [ ] iOS device, Triangle scheme: tap once anywhere; the hint appears at the bottom-right corner during gameplay
- [ ] iOS device, Triangle scheme: hint stays hidden on title screen and game-over overlay
- [ ] Native macOS: launch via the Mac scheme; hint never appears (no touch events)
- [ ] Web on desktop browser (keyboard): hint never appears
- [ ] Web on a phone (Safari): hint appears after the first tap
- [ ] Visual: glow is subtle enough to not compete with the bloom-driven neon palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)