### PR TITLE
Add title screen help overlay

### DIFF
--- a/_context/plans/active/near-term.md
+++ b/_context/plans/active/near-term.md
@@ -14,6 +14,9 @@ Used `fontdue` (pure Rust font rasterizer) instead of `glyphon` — glyphon does
 Tasks:
 - [x] Embed Pixel Six font via `include_bytes!` (already in repo from legacy)
 - [x] Implement `TextRenderer` struct (fontdue atlas + instanced glyph quads, WGSL shader)
+- [x] Snap bitmap text layout to whole pixels: integer glyph advances,
+      integer start positions, and integer render scales. This avoids long
+      strings (e.g. "TAP TO RESTART") accumulating fractional glyph positions.
 - [x] FPS counter + score debug overlay (toggle with F3)
 - [ ] In-game settings UI (see `autonomous-improvement.md` for design)
 
@@ -216,10 +219,15 @@ Brief tutorial reachable from the title screen. New players (especially on
 mobile) currently have no in-app way to learn the controls or objective.
 
 Tasks:
-- [ ] Add an "INSTRUCTIONS" / "?" button to the title screen
-- [ ] Overlay shows controls (touch zones + keyboard) and objective in a few lines
-- [ ] Tap-to-dismiss returns to title with no game-state side effects
-- [ ] Style consistent with existing `TextRenderer` + game palette
+- [x] Add an "INSTRUCTIONS" / "?" button to the title screen
+- [x] Overlay shows controls (touch zones + keyboard) and objective in a few lines
+- [x] Tap-to-dismiss returns to title with no game-state side effects
+- [x] Style consistent with existing `TextRenderer` + game palette
+- [x] Render help overlay into a game-resolution texture and composite it
+      post-bloom with nearest integer scaling, so the small pixel font stays
+      sharp and does not glow.
+- [x] Use a bottom-right `X` close button inside the overlay instead of a
+      textual close instruction.
 
 ---
 
@@ -230,8 +238,9 @@ knob; the player should be able to flip it from the title without editing
 TOML.
 
 Tasks:
-- [ ] Music icon button on the title screen (note glyph; slash overlay when muted)
-- [ ] Tap toggles whether music starts in the next play session
+- [x] Music ON/OFF button on the title screen
+- [x] Tap toggles current music playback from the title screen
+- [ ] Replace text button with compact icon treatment if/when Pixel Six has a good glyph
 - [ ] Persist the preference across launches (depends on §16)
 
 ---

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -143,6 +143,7 @@ pub struct AudioPlayer {
     playlist: Vec<usize>,
     playlist_pos: usize,
     playing: bool,
+    started: bool,
 }
 
 impl AudioPlayer {
@@ -154,6 +155,7 @@ impl AudioPlayer {
             playlist,
             playlist_pos: 0,
             playing: true,
+            started: true,
         };
         player.backend.start_track(first);
         player
@@ -165,6 +167,7 @@ impl AudioPlayer {
             playlist: shuffled_playlist(),
             playlist_pos: 0,
             playing: false,
+            started: false,
         }
     }
 
@@ -178,12 +181,21 @@ impl AudioPlayer {
     }
 
     pub fn toggle(&mut self) {
+        if !self.playing && !self.started {
+            self.backend.start_track(self.playlist[self.playlist_pos]);
+            self.started = true;
+        }
         self.playing = !self.playing;
         self.backend.set_playing(self.playing);
     }
 
+    pub fn is_playing(&self) -> bool {
+        self.playing
+    }
+
     pub fn next_track(&mut self) {
         self.playing = true;
+        self.started = true;
         self.backend.stop_current();
         self.playlist_pos = (self.playlist_pos + 1) % self.playlist.len();
         let next = self.playlist[self.playlist_pos];

--- a/src/input.rs
+++ b/src/input.rs
@@ -327,6 +327,12 @@ fn touch_delta_to_target_heading(
 }
 
 #[derive(Debug, Copy, Clone, Default)]
+pub struct PointerPress {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[derive(Debug, Copy, Clone, Default)]
 pub struct InputState {
     pub thrust: f32, // [0.0, 1.0]
     pub rotate: f32, // [-1.0, 1.0]; positive = CCW/left, negative = CW/right (keyboard only)
@@ -337,6 +343,8 @@ pub struct InputState {
 
     pub restart: bool,
     pub touch_started: bool,
+    pub pointer_pressed: Option<PointerPress>,
+    pub help: bool,
 
     pub pause: bool,
     pub fullscreen: bool,
@@ -394,6 +402,8 @@ struct TouchTracker {
     rotate_x: f32,
     rotate_y: f32,
     touch_started: bool,
+    touch_started_x: f32,
+    touch_started_y: f32,
     /// Sticky "any touch event has occurred this session" flag — used to
     /// detect that the player is on a touch device so we can show the
     /// touch-zone hint. Never resets after the first touch.
@@ -411,6 +421,8 @@ impl TouchTracker {
 
     fn started(&mut self, id: TouchId, x: f32, y: f32) {
         self.touch_started = true;
+        self.touch_started_x = x;
+        self.touch_started_y = y;
         self.ever_touched = true;
         if self.surface_width <= 0.0 || self.surface_height <= 0.0 {
             return;
@@ -450,10 +462,17 @@ impl TouchTracker {
         }
     }
 
-    fn consume_touch_started(&mut self) -> bool {
+    fn consume_touch_started(&mut self) -> Option<PointerPress> {
         let started = self.touch_started;
         self.touch_started = false;
-        started
+        if started {
+            Some(PointerPress {
+                x: self.touch_started_x,
+                y: self.touch_started_y,
+            })
+        } else {
+            None
+        }
     }
 
     fn current_input(&self, scheme: TouchControlScheme) -> TouchInput {
@@ -513,6 +532,10 @@ pub struct InputCollector {
     held_cam_perspective: bool,
     held_cam_reset: bool,
     restart_requested: bool,
+    help_requested: bool,
+    pointer_press: Option<PointerPress>,
+    cursor_x: f32,
+    cursor_y: f32,
 
     touch_scheme: TouchControlScheme,
 
@@ -542,6 +565,10 @@ impl Default for InputCollector {
             held_cam_perspective: false,
             held_cam_reset: false,
             restart_requested: false,
+            help_requested: false,
+            pointer_press: None,
+            cursor_x: 0.0,
+            cursor_y: 0.0,
             touch_scheme: TouchControlScheme::Drag,
             #[cfg(not(target_arch = "wasm32"))]
             touch: TouchTracker::default(),
@@ -691,6 +718,7 @@ impl InputCollector {
                 KeyCode::KeyD => self.held_right = pressed,
                 KeyCode::KeyP => self.held_pause = pressed,
                 KeyCode::KeyR if pressed => self.restart_requested = true,
+                KeyCode::KeyH | KeyCode::Slash if pressed => self.help_requested = true,
 
                 // Camera
                 KeyCode::KeyU => self.held_cam_in = pressed,
@@ -709,6 +737,23 @@ impl InputCollector {
             }
         }
 
+        match event {
+            winit::event::WindowEvent::CursorMoved { position, .. } => {
+                self.cursor_x = position.x as f32;
+                self.cursor_y = position.y as f32;
+            }
+            winit::event::WindowEvent::MouseInput { state, button, .. }
+                if *state == winit::event::ElementState::Pressed
+                    && *button == winit::event::MouseButton::Left =>
+            {
+                self.pointer_press = Some(PointerPress {
+                    x: self.cursor_x,
+                    y: self.cursor_y,
+                });
+            }
+            _ => {}
+        }
+
         // Native touch: winit relays WindowEvent::Touch on platforms with touch
         // support (iOS, Android, touchscreen desktops). Not available on WASM —
         // handled via DOM listeners registered in init_touch().
@@ -719,7 +764,10 @@ impl InputCollector {
             let y = touch.location.y as f32;
             let id = touch.id as i64;
             match touch.phase {
-                TouchPhase::Started => self.touch.started(id, x, y),
+                TouchPhase::Started => {
+                    self.pointer_press = Some(PointerPress { x, y });
+                    self.touch.started(id, x, y);
+                }
                 TouchPhase::Moved => self.touch.moved(id, x, y),
                 TouchPhase::Ended | TouchPhase::Cancelled => self.touch.ended(id),
             }
@@ -729,6 +777,9 @@ impl InputCollector {
     pub fn current_state(&mut self) -> InputState {
         let restart = self.restart_requested;
         self.restart_requested = false;
+        let help = self.help_requested;
+        self.help_requested = false;
+        let mut pointer_pressed = self.pointer_press.take();
 
         let keyboard_thrust = if self.held_thrust { 1.0 } else { 0.0 };
         let keyboard_rotate = match (self.held_left, self.held_right) {
@@ -739,7 +790,11 @@ impl InputCollector {
 
         #[cfg(not(target_arch = "wasm32"))]
         let (touch_started, touch_input) = {
-            let touch_started = self.touch.consume_touch_started();
+            let touch_press = self.touch.consume_touch_started();
+            if pointer_pressed.is_none() {
+                pointer_pressed = touch_press;
+            }
+            let touch_started = touch_press.is_some();
             let touch_input = self.touch.current_input(self.touch_scheme);
             (touch_started, touch_input)
         };
@@ -747,7 +802,11 @@ impl InputCollector {
         #[cfg(target_arch = "wasm32")]
         let (touch_started, touch_input) = {
             let mut touch = self.wasm_touch.borrow_mut();
-            let touch_started = touch.consume_touch_started();
+            let touch_press = touch.consume_touch_started();
+            if pointer_pressed.is_none() {
+                pointer_pressed = touch_press;
+            }
+            let touch_started = touch_press.is_some();
             let touch_input = touch.current_input(self.touch_scheme);
             (touch_started, touch_input)
         };
@@ -771,6 +830,8 @@ impl InputCollector {
             target_heading,
             restart,
             touch_started,
+            pointer_pressed,
+            help,
             pause: self.held_pause,
             fullscreen: self.held_fullscreen,
             cam_in: self.held_cam_in,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,4 +17,5 @@ pub mod shader_util;
 pub mod ship;
 pub mod text;
 pub mod textured_quad;
+pub mod title_overlay;
 pub mod touch_zone_indicator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,12 +10,13 @@ use spout::background;
 use spout::bloom;
 use spout::collision;
 use spout::game_params;
-use spout::input::{InputCollector, InputState};
+use spout::input::{InputCollector, InputState, PointerPress};
 use spout::level_manager;
 use spout::particles;
 use spout::render;
 use spout::ship;
 use spout::text;
+use spout::title_overlay;
 use spout::touch_zone_indicator;
 
 /// Shortest signed angular distance from `current` to `target`, in [-π, π].
@@ -101,8 +102,35 @@ struct GameState {
     score: i32,
     paused: bool,
     reset_requested: bool,
+    instructions_open: bool,
     dead: bool,
     explosion_pending: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TitleButtonAction {
+    Music,
+    Help,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct UiRect {
+    x: f32,
+    y: f32,
+    w: f32,
+    h: f32,
+}
+
+impl UiRect {
+    fn contains(&self, x: f32, y: f32) -> bool {
+        x >= self.x && x <= self.x + self.w && y >= self.y && y <= self.y + self.h
+    }
+}
+
+struct TitleButton {
+    action: TitleButtonAction,
+    label: &'static str,
+    rect: UiRect,
 }
 
 struct Spout {
@@ -113,9 +141,11 @@ struct Spout {
     game_time: std::time::Duration,
     iteration_start: Instant,
     game_view_texture: wgpu::TextureView,
+    title_ui_view: wgpu::TextureView,
     upscaled_view: wgpu::TextureView,
     bloom: bloom::Bloom,
     renderer: render::Render,
+    title_overlay: title_overlay::TitleOverlay,
     particle_system: particles::ParticleSystem,
     ship_renderer: ship::ShipRenderer,
     collision_detector: collision::CollisionDetector,
@@ -135,6 +165,213 @@ struct Spout {
 }
 
 impl Spout {
+    fn surface_to_game_point(
+        &self,
+        point: PointerPress,
+        surface_width: u32,
+        surface_height: u32,
+    ) -> Option<(f32, f32)> {
+        if surface_width == 0 || surface_height == 0 {
+            return None;
+        }
+
+        let game_w = self.game_params.viewport_width as f32;
+        let game_h = self.game_params.viewport_height as f32;
+        let surface_w = surface_width as f32;
+        let surface_h = surface_height as f32;
+        let scale = (surface_w / game_w)
+            .min(surface_h / game_h)
+            .floor()
+            .max(1.0);
+        let draw_w = game_w * scale;
+        let draw_h = game_h * scale;
+        let offset_x = ((surface_w - draw_w) * 0.5).floor();
+        let offset_y = ((surface_h - draw_h) * 0.5).floor();
+
+        if point.x < offset_x
+            || point.x > offset_x + draw_w
+            || point.y < offset_y
+            || point.y > offset_y + draw_h
+        {
+            return None;
+        }
+
+        let game_x = (point.x - offset_x) / draw_w * game_w;
+        // The game-view blit flips texture Y (see `textured_quad` UVs), so
+        // visual top on the surface corresponds to low Y in the game texture.
+        let game_y = (point.y - offset_y) / draw_h * game_h;
+        Some((game_x, game_y))
+    }
+
+    fn title_buttons(&self) -> Vec<TitleButton> {
+        let pad_x = 4.0;
+        let button_h = 32.0;
+        let help_y = self.game_params.viewport_height as f32 - button_h - 6.0;
+        let help_label = if self.state.instructions_open {
+            "X"
+        } else {
+            "?"
+        };
+        let mut buttons = vec![TitleButton {
+            action: TitleButtonAction::Help,
+            label: help_label,
+            rect: UiRect {
+                x: self.game_params.viewport_width as f32 - 56.0 - 6.0,
+                y: help_y,
+                w: 56.0,
+                h: button_h,
+            },
+        }];
+
+        if self.state.instructions_open {
+            let music_label = if self.audio.is_playing() {
+                "[MUSIC ON]"
+            } else {
+                "[MUSIC OFF]"
+            };
+            let music_w = self.game_text.text_width(music_label, 1.0) + pad_x * 2.0;
+            buttons.push(TitleButton {
+                action: TitleButtonAction::Music,
+                label: music_label,
+                rect: UiRect {
+                    x: 18.0,
+                    y: 100.0,
+                    w: music_w,
+                    h: button_h,
+                },
+            });
+        }
+
+        buttons
+    }
+
+    fn title_button_at(
+        &self,
+        point: PointerPress,
+        surface_width: u32,
+        surface_height: u32,
+    ) -> Option<TitleButtonAction> {
+        if self.title_help_surface_hit(point, surface_width, surface_height) {
+            return Some(TitleButtonAction::Help);
+        }
+
+        let (game_x, game_y) = self.surface_to_game_point(point, surface_width, surface_height)?;
+        self.title_buttons()
+            .iter()
+            .find(|button| button.rect.contains(game_x, game_y))
+            .map(|button| button.action)
+    }
+
+    fn title_help_surface_hit(
+        &self,
+        point: PointerPress,
+        surface_width: u32,
+        surface_height: u32,
+    ) -> bool {
+        let w = surface_width as f32;
+        let h = surface_height as f32;
+        point.x >= w * 0.72 && point.y >= h * 0.62
+    }
+
+    fn draw_title_help_button(&self, device: &wgpu::Device, encoder: &mut wgpu::CommandEncoder) {
+        if self.state.instructions_open {
+            return;
+        }
+
+        let Some(button) = self
+            .title_buttons()
+            .into_iter()
+            .find(|button| button.action == TitleButtonAction::Help)
+        else {
+            return;
+        };
+
+        let color = [0.55, 0.55, 0.55, 1.0];
+        let label_x =
+            button.rect.x + (button.rect.w - self.game_text.text_width(button.label, 1.0)) / 2.0;
+        let label_y = button.rect.y + (button.rect.h - 12.0) / 2.0;
+
+        self.game_text.draw(
+            device,
+            encoder,
+            &self.game_view_texture,
+            &[(button.label, label_x, label_y, 1.0, color)],
+        );
+    }
+
+    fn prepare_title_ui(&self, device: &wgpu::Device, encoder: &mut wgpu::CommandEncoder) {
+        let clear_color = if self.state.instructions_open {
+            wgpu::Color {
+                r: 0.02,
+                g: 0.05,
+                b: 0.07,
+                a: 0.76,
+            }
+        } else {
+            wgpu::Color::TRANSPARENT
+        };
+        {
+            let _pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("title_ui_clear"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.title_ui_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(clear_color),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                ..Default::default()
+            });
+        }
+
+        let button_color = [0.7, 0.78, 0.78, 1.0];
+        let text_color = [0.82, 0.86, 0.82, 1.0];
+        let accent_color = [0.9, 0.72, 0.48, 1.0];
+        let buttons = self.title_buttons();
+
+        let mut texts: Vec<(&str, f32, f32, f32, [f32; 4])> = Vec::new();
+        for button in buttons.iter().filter(|button| {
+            button.action != TitleButtonAction::Help || self.state.instructions_open
+        }) {
+            let scale = 1.0;
+            let label_x = button.rect.x
+                + (button.rect.w - self.game_text.text_width(button.label, scale)) / 2.0;
+            let label_y = button.rect.y + (button.rect.h - 12.0) / 2.0;
+            texts.push((button.label, label_x, label_y, scale, button_color));
+        }
+
+        if self.state.instructions_open {
+            let w = self.game_text.surface_width;
+            let scale = 1.0;
+            let using_touch = self.collector.has_been_touched() || tap_restart_prompt();
+            let lines: Vec<(&str, f32, [f32; 4])> = if using_touch {
+                vec![
+                    ("OBJECTIVE", 24.0, accent_color),
+                    ("BLAST AND CLIMB", 42.0, text_color),
+                    ("LEFT SIDE -> GAS", 64.0, text_color),
+                    ("RIGHT SIDE -> STEER", 82.0, text_color),
+                ]
+            } else {
+                vec![
+                    ("OBJECTIVE", 24.0, accent_color),
+                    ("BLAST AND CLIMB", 42.0, text_color),
+                    ("W -> GAS", 64.0, text_color),
+                    ("A/D -> STEER", 82.0, text_color),
+                ]
+            };
+            texts.extend(lines.into_iter().map(|(line, y, color)| {
+                let x = (w - self.game_text.text_width(line, scale)) / 2.0;
+                (line, x, y, scale, color)
+            }));
+        }
+
+        self.game_text
+            .draw(device, encoder, &self.title_ui_view, &texts);
+    }
+
     fn enter_title(&mut self, device: &wgpu::Device, queue: &wgpu::Queue) {
         // Preserve input state across transitions to avoid false edges
         // (e.g. fullscreen toggle firing because prev_input was cleared).
@@ -451,6 +688,11 @@ impl framework::Example for Spout {
             game_params.viewport_width,
             game_params.viewport_height,
         );
+        let title_ui_view = make_texture(
+            device,
+            game_params.viewport_width,
+            game_params.viewport_height,
+        );
 
         let upscaled_view = make_texture(device, config.width, config.height);
 
@@ -490,6 +732,15 @@ impl framework::Example for Spout {
             &game_view_texture,
             &upscaled_view,
             bloom.bloom_view(),
+        );
+        let title_overlay = title_overlay::TitleOverlay::new(
+            device,
+            config.format,
+            &title_ui_view,
+            config.width,
+            config.height,
+            game_params.viewport_width,
+            game_params.viewport_height,
         );
 
         let particle_system =
@@ -562,9 +813,11 @@ impl framework::Example for Spout {
             game_time: std::time::Duration::default(),
             iteration_start: Instant::now(),
             game_view_texture,
+            title_ui_view,
             upscaled_view,
             bloom,
             renderer,
+            title_overlay,
             particle_system,
             ship_renderer,
             collision_detector,
@@ -633,6 +886,13 @@ impl framework::Example for Spout {
         self.renderer
             .resize(config, device, &new_upscaled, self.bloom.bloom_view());
         self.upscaled_view = new_upscaled;
+        self.title_overlay.resize_with_game(
+            queue,
+            config.width,
+            config.height,
+            self.game_params.viewport_width,
+            self.game_params.viewport_height,
+        );
         self.touch_zone_indicator
             .resize(queue, config.width, config.height);
         #[cfg(debug_assertions)]
@@ -659,6 +919,7 @@ impl framework::Example for Spout {
 
         // Update input and game state first, so transitions see correct prev/current.
         self.update_state();
+        let win_size = window.inner_size();
 
         // Fullscreen toggle (edge-triggered, independent of game state).
         if !self.state.prev_input_state.fullscreen && self.state.input_state.fullscreen {
@@ -676,12 +937,36 @@ impl framework::Example for Spout {
             self.state.reset_requested = false;
             self.enter_title(device, queue);
         } else if self.state.mode == GameMode::Title {
+            let input = self.state.input_state;
+            let clicked_button = input
+                .pointer_pressed
+                .and_then(|point| self.title_button_at(point, win_size.width, win_size.height));
+            let mut title_action_handled = false;
+
+            if input.help {
+                self.state.instructions_open = !self.state.instructions_open;
+                title_action_handled = true;
+            }
+
+            if let Some(action) = clicked_button {
+                match action {
+                    TitleButtonAction::Music => self.audio.toggle(),
+                    TitleButtonAction::Help => {
+                        self.state.instructions_open = !self.state.instructions_open;
+                    }
+                }
+                title_action_handled = true;
+            } else if self.state.instructions_open && input.pointer_pressed.is_some() {
+                self.state.instructions_open = false;
+                title_action_handled = true;
+            }
+
             // Start game on a NEW press of thrust or rotate (edge, not held).
-            let input = &self.state.input_state;
-            let prev = &self.state.prev_input_state;
+            let prev = self.state.prev_input_state;
             let new_thrust = input.thrust > 0.0 && prev.thrust == 0.0;
             let new_rotate = input.rotate.abs() > 0.0 && prev.rotate.abs() == 0.0;
-            if new_thrust || new_rotate {
+            if !title_action_handled && !self.state.instructions_open && (new_thrust || new_rotate)
+            {
                 self.start_game(device, queue);
             }
         }
@@ -745,6 +1030,11 @@ impl framework::Example for Spout {
         // Render particles.
         self.particle_system
             .render(&self.game_view_texture, &mut encoder);
+
+        if self.state.mode == GameMode::Title {
+            self.draw_title_help_button(device, &mut encoder);
+            self.prepare_title_ui(device, &mut encoder);
+        }
 
         // Render ship — only during gameplay, and not when dead.
         if self.state.mode == GameMode::Playing && self.game_params.render_ship && !self.state.dead
@@ -820,6 +1110,10 @@ impl framework::Example for Spout {
         // Composite upscaled HDR + bloom → surface (LDR).
         self.renderer.render(view, &mut encoder);
 
+        if self.state.mode == GameMode::Title {
+            self.title_overlay.render(view, &mut encoder);
+        }
+
         // Touch-zone diagonal hint. Only render if:
         //   - Triangle scheme is active,
         //   - the player has actually used touch this session (so it stays
@@ -844,7 +1138,6 @@ impl framework::Example for Spout {
         self.frame_times.push(dt);
         let avg_dt = self.frame_times.iter().sum::<f32>() / self.frame_times.len() as f32;
         let fps = if avg_dt > 0.0 { 1.0 / avg_dt } else { 0.0 };
-        let win_size = window.inner_size();
         let w = win_size.width;
         let h = win_size.height;
 

--- a/src/shaders/title_overlay.wgsl
+++ b/src/shaders/title_overlay.wgsl
@@ -1,0 +1,49 @@
+// Low-resolution title UI overlay.
+//
+// Samples a game-resolution RGBA texture after the main bloom composite and
+// alpha-blends it onto the surface. The texture is integer-scaled with nearest
+// sampling so each source pixel covers a uniform display-sized block.
+
+struct Uniforms {
+    surface_size: vec2<f32>,
+    game_size: vec2<f32>,
+};
+
+@group(0) @binding(0) var<uniform> u: Uniforms;
+@group(0) @binding(1) var overlay_tex: texture_2d<f32>;
+@group(0) @binding(2) var overlay_sampler: sampler;
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) screen_px: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
+    let x = f32(vi & 1u);
+    let y = f32(vi >> 1u);
+    let ndc = vec2<f32>(x * 2.0 - 1.0, 1.0 - y * 2.0);
+
+    var out: VertexOutput;
+    out.position = vec4<f32>(ndc, 0.0, 1.0);
+    out.screen_px = vec2<f32>(x * u.surface_size.x, y * u.surface_size.y);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let raw_scale = min(u.surface_size.x / u.game_size.x, u.surface_size.y / u.game_size.y);
+    let pixel_scale = max(floor(raw_scale), 1.0);
+    let draw_size = u.game_size * pixel_scale;
+    let offset = floor((u.surface_size - draw_size) * 0.5);
+
+    let local = (in.screen_px - offset) / draw_size;
+    if any(local < vec2<f32>(0.0)) || any(local > vec2<f32>(1.0)) {
+        return vec4<f32>(0.0);
+    }
+
+    // The main game blit flips the game texture vertically. Use the same
+    // convention so UI coordinates match title hit-testing and TextRenderer.
+    let uv = vec2<f32>(local.x, 1.0 - local.y);
+    return textureSampleLevel(overlay_tex, overlay_sampler, uv, 0.0);
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,6 +1,5 @@
 //! Bitmap font text renderer using `fontdue` for glyph rasterization and a
-//! GPU texture atlas. Designed for the Pixel Six 8px bitmap font but works
-//! with any TTF/OTF.
+//! GPU texture atlas. Designed for pixel fonts but works with any TTF/OTF.
 
 use wgpu::util::DeviceExt;
 
@@ -50,7 +49,7 @@ struct GlyphInfo {
     /// Offset from the pen position to the top-left of the glyph bitmap.
     x_offset: f32,
     y_offset: f32,
-    /// Horizontal advance to the next glyph.
+    /// Horizontal advance to the next glyph, snapped to whole pixels.
     advance: f32,
 }
 
@@ -92,6 +91,10 @@ pub struct TextRenderer {
 }
 
 impl TextRenderer {
+    fn pixel_scale(scale: f32) -> f32 {
+        scale.round().max(1.0)
+    }
+
     pub fn init(
         device: &wgpu::Device,
         queue: &wgpu::Queue,
@@ -165,7 +168,7 @@ impl TextRenderer {
                 height: gh as f32,
                 x_offset: metrics.xmin as f32,
                 y_offset: metrics.ymin as f32,
-                advance: metrics.advance_width,
+                advance: metrics.advance_width.round().max(0.0),
             });
 
             cursor_x += gw + padding;
@@ -365,13 +368,14 @@ impl TextRenderer {
 
     /// Measure the width of a text string in pixels at the given scale.
     pub fn text_width(&self, text: &str, scale: f32) -> f32 {
+        let pixel_scale = Self::pixel_scale(scale);
         let mut w = 0.0;
         for ch in text.bytes() {
             if !(FIRST_CHAR..=LAST_CHAR).contains(&ch) {
                 continue;
             }
             let idx = (ch - FIRST_CHAR) as usize;
-            w += self.glyphs[idx].advance * scale;
+            w += self.glyphs[idx].advance * pixel_scale;
         }
         w
     }
@@ -399,7 +403,9 @@ impl TextRenderer {
         let mut instances: Vec<GlyphInstance> = Vec::new();
 
         for &(text, start_x, start_y, scale, color) in texts {
-            let mut pen_x = start_x;
+            let pixel_scale = Self::pixel_scale(scale);
+            let line_top = start_y.round();
+            let mut pen_x = start_x.round();
             for ch in text.bytes() {
                 if !(FIRST_CHAR..=LAST_CHAR).contains(&ch) {
                     continue;
@@ -410,18 +416,18 @@ impl TextRenderer {
                 if g.width > 0.0 && g.height > 0.0 {
                     // In screen coords (y-down), baseline is at start_y + ascent.
                     // Glyph top = baseline - (ymin + height), bottom = baseline - ymin.
-                    let baseline_y = start_y + self.ascent * scale;
-                    let glyph_top = baseline_y - (g.y_offset + g.height) * scale;
+                    let baseline_y = line_top + self.ascent * pixel_scale;
+                    let glyph_top = (baseline_y - (g.y_offset + g.height) * pixel_scale).round();
 
                     instances.push(GlyphInstance {
-                        pos: [pen_x + g.x_offset * scale, glyph_top],
-                        size: [g.width * scale, g.height * scale],
+                        pos: [(pen_x + g.x_offset * pixel_scale).round(), glyph_top],
+                        size: [g.width * pixel_scale, g.height * pixel_scale],
                         uv: [g.uv_x, g.uv_y, g.uv_x + g.uv_w, g.uv_y + g.uv_h],
                         color,
                     });
                 }
 
-                pen_x += g.advance * scale;
+                pen_x = (pen_x + g.advance * pixel_scale).round();
             }
         }
 

--- a/src/title_overlay.rs
+++ b/src/title_overlay.rs
@@ -1,0 +1,235 @@
+//! Post-bloom low-resolution UI overlay for the title screen.
+
+use wgpu::util::DeviceExt;
+
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct Uniforms {
+    surface_size: [f32; 2],
+    game_size: [f32; 2],
+}
+
+pub struct TitleOverlay {
+    pipeline: wgpu::RenderPipeline,
+    bind_group: wgpu::BindGroup,
+    uniform_buf: wgpu::Buffer,
+}
+
+impl TitleOverlay {
+    pub fn new(
+        device: &wgpu::Device,
+        surface_format: wgpu::TextureFormat,
+        overlay_view: &wgpu::TextureView,
+        surface_width: u32,
+        surface_height: u32,
+        game_width: u32,
+        game_height: u32,
+    ) -> Self {
+        let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("title_overlay_uniform"),
+            contents: bytemuck::bytes_of(&Uniforms {
+                surface_size: [surface_width as f32, surface_height as f32],
+                game_size: [game_width as f32, game_height as f32],
+            }),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("title_overlay_sampler"),
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("title_overlay_bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(
+                            std::mem::size_of::<Uniforms>() as u64
+                        ),
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("title_overlay_bg"),
+            layout: &bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: uniform_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(overlay_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+            ],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("title_overlay_shader"),
+            source: wgpu::ShaderSource::Wgsl(crate::include_shader!("title_overlay.wgsl")),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("title_overlay_layout"),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("title_overlay"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            cache: None,
+            multiview_mask: None,
+        });
+
+        TitleOverlay {
+            pipeline,
+            bind_group,
+            uniform_buf,
+        }
+    }
+
+    pub fn resize_with_game(
+        &self,
+        queue: &wgpu::Queue,
+        surface_width: u32,
+        surface_height: u32,
+        game_width: u32,
+        game_height: u32,
+    ) {
+        queue.write_buffer(
+            &self.uniform_buf,
+            0,
+            bytemuck::bytes_of(&Uniforms {
+                surface_size: [surface_width as f32, surface_height as f32],
+                game_size: [game_width as f32, game_height as f32],
+            }),
+        );
+    }
+
+    pub fn render(&self, view: &wgpu::TextureView, encoder: &mut wgpu::CommandEncoder) {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("title_overlay"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            ..Default::default()
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &self.bind_group, &[]);
+        pass.draw(0..4, 0..1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_title_overlay_render_headless() {
+        let Some((device, queue)) = crate::gpu_test_utils::try_create_headless_device() else {
+            eprintln!("No headless GPU adapter available; skipping title overlay test");
+            return;
+        };
+
+        let overlay_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("title overlay test source"),
+            size: wgpu::Extent3d {
+                width: 64,
+                height: 32,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: crate::bloom::GAME_VIEW_FORMAT,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let overlay_view = overlay_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let target = crate::gpu_test_utils::create_offscreen_target(
+            &device,
+            64,
+            64,
+            wgpu::TextureFormat::Bgra8UnormSrgb,
+        );
+
+        let overlay = TitleOverlay::new(
+            &device,
+            wgpu::TextureFormat::Bgra8UnormSrgb,
+            &overlay_view,
+            64,
+            64,
+            64,
+            32,
+        );
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        crate::gpu_test_utils::encode_clear_texture(&mut encoder, &target.view);
+        overlay.render(&target.view, &mut encoder);
+        queue.submit(Some(encoder.finish()));
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("title overlay GPU test should poll submitted work");
+    }
+}


### PR DESCRIPTION
## Summary
- add title-screen ?/X help overlay with pixel-font control instructions and music toggle
- composite overlay from a game-resolution texture after bloom with nearest integer scaling
- snap bitmap text layout to whole pixels to avoid warped long strings
- add pointer/touch click plumbing for title UI and update near-term plan notes

## Tests
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test --verbose

Note: cargo test still prints the existing readonly global-cache last-use warning, but all tests pass.