### PR TITLE
feat(offscreen): add small overlay window when ship is off the screen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod gpu_test_utils;
 pub mod input;
 pub mod level_manager;
 pub mod particles;
+pub mod pip;
 pub mod render;
 pub mod shader_util;
 pub mod ship;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use spout::game_params;
 use spout::input::{InputCollector, InputState};
 use spout::level_manager;
 use spout::particles;
+use spout::pip;
 use spout::render;
 use spout::ship;
 use spout::text;
@@ -67,6 +68,7 @@ struct Spout {
     renderer: render::Render,
     particle_system: particles::ParticleSystem,
     ship_renderer: ship::ShipRenderer,
+    pip_renderer: pip::PipRenderer,
     collision_detector: collision::CollisionDetector,
     background: background::BackgroundRenderer,
     /// Renders into the game view (240x135) — pixel-perfect with terrain/particles.
@@ -430,6 +432,7 @@ impl framework::Example for Spout {
             particles::ParticleSystem::new(device, &game_params, &mut init_encoder, &level_manager);
 
         let ship_renderer = ship::ShipRenderer::init(device);
+        let pip_renderer = pip::PipRenderer::init(device);
         let collision_detector = collision::CollisionDetector::init(device);
         let background = background::BackgroundRenderer::init(device, queue);
 
@@ -493,6 +496,7 @@ impl framework::Example for Spout {
             renderer,
             particle_system,
             ship_renderer,
+            pip_renderer,
             collision_detector,
             background,
             game_text,
@@ -691,6 +695,55 @@ impl framework::Example for Spout {
                 &self.game_view_texture,
                 &mut encoder,
                 &mut self.staging_belt,
+            );
+        }
+
+        // PIP overlay — shown when the ship is outside the visible viewport.
+        if self.state.mode == GameMode::Playing
+            && !self.state.dead
+            && pip::PipRenderer::is_ship_offscreen(
+                self.state.ship_state.position[1],
+                self.state.viewport_offset,
+                self.game_params.viewport_height,
+            )
+        {
+            self.pip_renderer.render(
+                self.state.ship_state.position,
+                self.state.ship_state.orientation,
+                self.state.input_state.thrust > 0.0,
+                &self.game_params,
+                &self.game_view_texture,
+                &mut encoder,
+                &mut self.staging_belt,
+            );
+
+            // Distance label centred inside the PIP panel.
+            // game_text uses y-from-top; convert the panel centre (pip.wgsl uses
+            // y-from-bottom) with:  text_y = viewport_height - world_y_from_bottom.
+            let dist = (self.state.viewport_offset
+                - self.state.ship_state.position[1] as i32)
+                .max(0);
+            let dist_text = format!("-{}", dist);
+            let scale = 0.65;
+            let pip_cx = pip::PipRenderer::pip_center_x(
+                self.state.ship_state.position[0],
+                self.game_params.viewport_width,
+            );
+            let tw = self.game_text.text_width(&dist_text, scale);
+            let tx = pip_cx - tw / 2.0;
+            // Place the text just above the panel top edge.
+            // Panel top = PIP_CENTER_Y + PIP_HH from screen bottom.
+            // game_text y=0 is screen top, so convert and leave a 2 px gap.
+            let font_h = 16.0 * scale;
+            let panel_top_gt = self.game_params.viewport_height as f32
+                - (pip::PIP_CENTER_Y + pip::PIP_HH);
+            let ty = panel_top_gt - font_h - 2.0;
+            let amber = [1.0, 0.75, 0.15, 1.0];
+            self.game_text.draw(
+                device,
+                &mut encoder,
+                &self.game_view_texture,
+                &[(&dist_text, tx, ty, scale, amber)],
             );
         }
 

--- a/src/pip.rs
+++ b/src/pip.rs
@@ -1,0 +1,303 @@
+//! Picture-in-Picture overlay: shows a miniature ship + glowing frame at the
+//! bottom of the game view when the ship has scrolled outside the visible area.
+
+use crate::{bloom, buffer_util::SizedBuffer, game_params};
+
+/// Half-width / half-height of the panel in game-view pixels.
+pub const PIP_HW: f32 = 15.0;
+pub const PIP_HH: f32 = 11.0;
+/// Fixed Y coordinate of the panel centre (game-view, Y-up).
+pub const PIP_CENTER_Y: f32 = 14.0;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct PipUniforms {
+    pip_center: [f32; 2],
+    ship_orientation: f32,
+    viewport_width: u32,
+    viewport_height: u32,
+    _pad: u32,
+}
+
+pub struct PipRenderer {
+    uniform_buffer: SizedBuffer,
+    bind_group: wgpu::BindGroup,
+    bg_pipeline: wgpu::RenderPipeline,
+    brackets_pipeline: wgpu::RenderPipeline,
+    ship_pipeline: wgpu::RenderPipeline,
+    outline_pipeline: wgpu::RenderPipeline,
+    flame_pipeline: wgpu::RenderPipeline,
+}
+
+impl PipRenderer {
+    pub fn init(device: &wgpu::Device) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("pip_shader"),
+            source: wgpu::ShaderSource::Wgsl(crate::include_shader!("pip.wgsl")),
+        });
+
+        let init_uniforms = PipUniforms {
+            pip_center: [0.0, PIP_CENTER_Y],
+            ship_orientation: 0.0,
+            viewport_width: 0,
+            viewport_height: 0,
+            _pad: 0,
+        };
+        let uniform_buffer = crate::buffer_util::make_uniform_buffer(
+            device,
+            "PIP Uniform Buffer",
+            &init_uniforms,
+        );
+
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("PIP BGL"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(uniform_buffer.size as _),
+                },
+                count: None,
+            }],
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("PIP BG"),
+            layout: &bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.buffer.as_entire_binding(),
+            }],
+        });
+
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("PIP pipeline layout"),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+
+        let target = wgpu::ColorTargetState {
+            format: bloom::GAME_VIEW_FORMAT,
+            blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+            write_mask: wgpu::ColorWrites::ALL,
+        };
+
+        let bg_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("pip_bg"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_bg"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_bg"),
+                targets: &[Some(target.clone())],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            cache: None,
+            multiview_mask: None,
+        });
+
+        let brackets_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("pip_brackets"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_brackets"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_brackets"),
+                targets: &[Some(target.clone())],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::LineList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            cache: None,
+            multiview_mask: None,
+        });
+
+        let ship_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("pip_ship"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_ship"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_ship"),
+                targets: &[Some(target.clone())],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            cache: None,
+            multiview_mask: None,
+        });
+
+        let outline_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("pip_outline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_outline"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_outline"),
+                targets: &[Some(target.clone())],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::LineStrip,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            cache: None,
+            multiview_mask: None,
+        });
+
+        let flame_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("pip_flame"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_flame"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_flame"),
+                targets: &[Some(target)],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            cache: None,
+            multiview_mask: None,
+        });
+
+        PipRenderer {
+            uniform_buffer,
+            bind_group,
+            bg_pipeline,
+            brackets_pipeline,
+            ship_pipeline,
+            outline_pipeline,
+            flame_pipeline,
+        }
+    }
+
+    /// Returns true when the ship's Y world coordinate is outside the visible viewport.
+    pub fn is_ship_offscreen(ship_y: f32, viewport_offset: i32, viewport_height: u32) -> bool {
+        let vp_bot = viewport_offset as f32;
+        let vp_top = vp_bot + viewport_height as f32;
+        ship_y < vp_bot || ship_y > vp_top
+    }
+
+    /// The horizontal centre of the PIP panel, clamped so the box stays on screen.
+    pub fn pip_center_x(ship_x: f32, viewport_width: u32) -> f32 {
+        let margin = PIP_HW + 2.0;
+        ship_x.clamp(margin, viewport_width as f32 - margin)
+    }
+
+    // All arguments are distinct GPU/game concerns; grouping them would not
+    // simplify call sites.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render(
+        &mut self,
+        ship_pos: [f32; 2],
+        ship_orientation: f32,
+        is_thrusting: bool,
+        game_params: &game_params::GameParams,
+        output: &wgpu::TextureView,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
+    ) {
+        let pip_cx = Self::pip_center_x(ship_pos[0], game_params.viewport_width);
+
+        let uniforms = PipUniforms {
+            pip_center: [pip_cx, PIP_CENTER_Y],
+            ship_orientation,
+            viewport_width: game_params.viewport_width,
+            viewport_height: game_params.viewport_height,
+            _pad: 0,
+        };
+        belt.write_buffer(
+            encoder,
+            &self.uniform_buffer.buffer,
+            0,
+            // safe: buffer was created with this exact size
+            wgpu::BufferSize::new(self.uniform_buffer.size as _).unwrap(),
+        )
+        .copy_from_slice(bytemuck::bytes_of(&uniforms));
+
+        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("pip"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: output,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        rpass.set_bind_group(0, &self.bind_group, &[]);
+
+        rpass.set_pipeline(&self.bg_pipeline);
+        rpass.draw(0..6, 0..1);
+
+        rpass.set_pipeline(&self.brackets_pipeline);
+        rpass.draw(0..16, 0..1);
+
+        // Flame behind the ship — drawn before the ship fill so the hull occludes the base.
+        if is_thrusting {
+            rpass.set_pipeline(&self.flame_pipeline);
+            rpass.draw(0..3, 0..1);
+        }
+
+        rpass.set_pipeline(&self.ship_pipeline);
+        rpass.draw(0..6, 0..1);
+
+        rpass.set_pipeline(&self.outline_pipeline);
+        rpass.draw(0..5, 0..1);
+    }
+}

--- a/src/shaders/pip.wgsl
+++ b/src/shaders/pip.wgsl
@@ -1,0 +1,124 @@
+// Picture-in-Picture overlay: dark panel + glowing corner brackets + mini ship + thruster flame.
+// All coordinates are in game-view pixel space (origin bottom-left, Y up).
+// The panel is placed at a fixed Y near the bottom; its X tracks the ship's world X.
+
+const PIP_HW: f32 = 15.0;      // panel half-width  (total 30 px)
+const PIP_HH: f32 = 11.0;      // panel half-height (total 22 px)
+const BRACKET: f32 = 5.0;      // length of each corner tick
+const SHIP_SCALE: f32 = 0.52;  // mini-ship scale factor
+
+struct Uniforms {
+    pip_center: vec2<f32>,
+    ship_orientation: f32,
+    viewport_width: u32,
+    viewport_height: u32,
+    _pad: u32,
+}
+@group(0) @binding(0)
+var<uniform> u: Uniforms;
+
+struct VO { @builtin(position) pos: vec4<f32> }
+
+// Game-view pixel → NDC.
+// The game view texture is displayed via a textured quad that maps texel row 0
+// to the bottom of the screen (UV flip).  In the render target NDC Y=+1 therefore
+// ends up at the bottom of the final display, so we must invert Y here to match
+// the rest of the game's shaders (ship, terrain, etc.).
+fn px_ndc(p: vec2<f32>) -> vec2<f32> {
+    return vec2<f32>(
+         2.0 * p.x / f32(u.viewport_width) - 1.0,
+        1.0 - 2.0 * p.y / f32(u.viewport_height),
+    );
+}
+
+fn rot2(a: f32) -> mat2x2<f32> {
+    return mat2x2<f32>(vec2(cos(a), sin(a)), vec2(-sin(a), cos(a)));
+}
+
+// ── Background panel ───────────────────────────────────────────────────────────
+
+var<private> bg: array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+    vec2(-PIP_HW, -PIP_HH), vec2( PIP_HW, -PIP_HH), vec2( PIP_HW,  PIP_HH),
+    vec2(-PIP_HW, -PIP_HH), vec2( PIP_HW,  PIP_HH), vec2(-PIP_HW,  PIP_HH),
+);
+
+@vertex fn vs_bg(@builtin(vertex_index) i: u32) -> VO {
+    return VO(vec4(px_ndc(bg[i] + u.pip_center), 0.0, 1.0));
+}
+@fragment fn fs_bg() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.02, 0.06, 0.20, 0.82);  // dark navy, semi-transparent
+}
+
+// ── Corner brackets (LineList, 16 verts = 8 segments) ─────────────────────────
+// Each corner: two L-shaped ticks. Order: TL, TR, BR, BL.
+
+var<private> bk: array<vec2<f32>, 16> = array<vec2<f32>, 16>(
+    // Top-left
+    vec2(-PIP_HW, PIP_HH - BRACKET), vec2(-PIP_HW,            PIP_HH),
+    vec2(-PIP_HW,            PIP_HH), vec2(-PIP_HW + BRACKET,  PIP_HH),
+    // Top-right
+    vec2( PIP_HW - BRACKET,  PIP_HH), vec2( PIP_HW,            PIP_HH),
+    vec2( PIP_HW,            PIP_HH), vec2( PIP_HW, PIP_HH - BRACKET),
+    // Bottom-right
+    vec2( PIP_HW, -PIP_HH + BRACKET), vec2( PIP_HW,           -PIP_HH),
+    vec2( PIP_HW,           -PIP_HH), vec2( PIP_HW - BRACKET, -PIP_HH),
+    // Bottom-left
+    vec2(-PIP_HW + BRACKET, -PIP_HH), vec2(-PIP_HW,           -PIP_HH),
+    vec2(-PIP_HW,           -PIP_HH), vec2(-PIP_HW, -PIP_HH + BRACKET),
+);
+
+@vertex fn vs_brackets(@builtin(vertex_index) i: u32) -> VO {
+    return VO(vec4(px_ndc(bk[i] + u.pip_center), 0.0, 1.0));
+}
+@fragment fn fs_brackets() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.15, 1.1, 2.6, 1.0);  // electric cyan — HDR → bloom
+}
+
+// ── Mini ship body (TriangleList, 6 verts) ─────────────────────────────────────
+// Shifted slightly upward inside the panel to leave room for the distance label.
+const SHIP_LIFT: f32 = 1.5;
+
+var<private> sv: array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+    vec2( 12.0,  0.0), vec2( -8.0,  9.0), vec2( -5.0,  0.0),
+    vec2( 12.0,  0.0), vec2( -5.0,  0.0), vec2( -8.0, -9.0),
+);
+
+@vertex fn vs_ship(@builtin(vertex_index) i: u32) -> VO {
+    let local = SHIP_SCALE * (rot2(u.ship_orientation) * sv[i]) + vec2(0.0, SHIP_LIFT);
+    return VO(vec4(px_ndc(local + u.pip_center), 0.0, 1.0));
+}
+@fragment fn fs_ship() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.20, 0.35, 0.65, 0.92);  // steel-blue fill
+}
+
+// ── Mini ship outline (LineStrip, 5 verts) ─────────────────────────────────────
+
+var<private> ov: array<vec2<f32>, 5> = array<vec2<f32>, 5>(
+    vec2( 12.0,  0.0), vec2( -8.0,  9.0), vec2( -5.0,  0.0),
+    vec2( -8.0, -9.0), vec2( 12.0,  0.0),
+);
+
+@vertex fn vs_outline(@builtin(vertex_index) i: u32) -> VO {
+    let local = SHIP_SCALE * (rot2(u.ship_orientation) * ov[i]) + vec2(0.0, SHIP_LIFT);
+    return VO(vec4(px_ndc(local + u.pip_center), 0.0, 1.0));
+}
+@fragment fn fs_outline() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.3, 0.7, 2.2, 1.0);  // bright electric blue — HDR → bloom
+}
+
+// ── Thruster flame (TriangleList, 3 verts) ─────────────────────────────────────
+// Drawn only when thrusting (rust side passes draw count 3 or 0).
+
+var<private> fv: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+    vec2( -5.0,  3.2),   // left base, at tail notch
+    vec2( -5.0, -3.2),   // right base
+    vec2(-17.0,  0.0),   // flame tip — extends well behind the ship
+);
+
+@vertex fn vs_flame(@builtin(vertex_index) i: u32) -> VO {
+    let local = SHIP_SCALE * (rot2(u.ship_orientation) * fv[i]) + vec2(0.0, SHIP_LIFT);
+    return VO(vec4(px_ndc(local + u.pip_center), 0.0, 1.0));
+}
+@fragment fn fs_flame() -> @location(0) vec4<f32> {
+    return vec4<f32>(2.8, 1.0, 0.05, 0.88);  // hot orange — HDR → bloom
+}


### PR DESCRIPTION
Adding a Picture-In-Picture window which appears when the ship is off the screen. The window is  horizontally aligned with the ship and includes some text showing how far outside the screen the ship is. 

100% coded by claude.