### PR TITLE
Use exact collision progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.DS_Store
 **/*.rs.bk
 # Generated test output PNGs (not committed; only tests/golden/ is committed).
 /tests/output/*.png

--- a/_context/plans/active/near-term.md
+++ b/_context/plans/active/near-term.md
@@ -38,6 +38,13 @@ Tasks:
 - [ ] Test at different speeds: fast-moving ships may tunnel through 1-cell walls
   between frames; the per-point sweep handles moderate speeds but extreme
   velocities could still tunnel if the swept distance exceeds cell size.
+- [x] Exact collision-based progress: collision readback now reports impact
+  time along the tested movement segment, and score progress is only committed
+  once that segment is confirmed clear or resolved to its impact point. Camera
+  progress follows the live ship immediately, while one pending collision
+  segment extends to the latest live ship position during readback delay. The
+  collision shader checks the current 28 sampled hull points in a 32-lane
+  workgroup and reduces to the earliest impact in workgroup memory.
 
 ---
 

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -2,7 +2,8 @@
 //!
 //! Runs a compute shader that Bresenham-walks each hull vertex from its
 //! previous to current position, checking the GPU terrain buffer. Returns
-//! a hit flag and the axis-aligned contact normal for bouncing.
+//! a hit flag, axis-aligned contact normal, and impact time along the swept
+//! movement segment.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -27,19 +28,32 @@ struct CollisionUniforms {
 }
 
 /// Collision result read back from the GPU.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct CollisionResult {
     pub hit: bool,
     /// Axis-aligned contact normal: e.g. (1,0) = hit from the left,
     /// (0,-1) = hit from above.
     pub normal: [f32; 2],
+    /// Fraction along the swept movement segment where collision first occurs.
+    /// `0.0` is the previous ship state; `1.0` is the current ship state.
+    pub impact_t: f32,
+}
+
+impl Default for CollisionResult {
+    fn default() -> Self {
+        Self {
+            hit: false,
+            normal: [0.0, 0.0],
+            impact_t: 1.0,
+        }
+    }
 }
 
 pub struct CollisionDetector {
     pipeline: wgpu::ComputePipeline,
     bind_group_layout: wgpu::BindGroupLayout,
     uniform_buffer: SizedBuffer,
-    /// GPU-side result buffer (3 x u32). Written by the compute shader.
+    /// GPU-side result buffer (4 x u32). Written by the compute shader.
     result_buffer: wgpu::Buffer,
     /// CPU-readable staging buffer for async readback.
     staging_buffer: wgpu::Buffer,
@@ -126,16 +140,16 @@ impl CollisionDetector {
         let uniform_buffer =
             crate::buffer_util::make_uniform_buffer(device, "Collision Uniform Buffer", &uniforms);
 
-        // 3 x u32: [hit, normal_x_bits, normal_y_bits]
+        // 4 x u32: [hit, normal_x_bits, normal_y_bits, impact_t_bits]
         let result_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Collision Result"),
-            contents: bytemuck::cast_slice(&[0u32; 3]),
+            contents: bytemuck::cast_slice(&[0u32; 4]),
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
         });
 
         let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Collision Staging"),
-            size: 12, // 3 x u32
+            size: 16, // 4 x u32
             usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
@@ -166,9 +180,9 @@ impl CollisionDetector {
         prev_ship: &crate::ship::ShipState,
         terrain: &crate::level_manager::TerrainTile,
         terrain_width: u32,
-    ) {
+    ) -> bool {
         if self.pending_readback {
-            return;
+            return false;
         }
         let uniforms = CollisionUniforms {
             ship_x: ship.position[0],
@@ -221,8 +235,9 @@ impl CollisionDetector {
             cpass.dispatch_workgroups(1, 1, 1);
         }
 
-        encoder.copy_buffer_to_buffer(&self.result_buffer, 0, &self.staging_buffer, 0, 12);
+        encoder.copy_buffer_to_buffer(&self.result_buffer, 0, &self.staging_buffer, 0, 16);
         self.pending_readback = true;
+        true
     }
 
     /// Initiate async mapping of the staging buffer. Call after `queue.submit()`
@@ -245,26 +260,29 @@ impl CollisionDetector {
     /// Returns immediately if the mapping hasn't completed yet (WASM-safe).
     /// Caller is responsible for driving wgpu callbacks (device.poll) before
     /// calling this — see render() in main.rs.
-    pub fn poll_result(&mut self) {
+    pub fn poll_result(&mut self) -> Option<CollisionResult> {
         if !self.pending_readback || !self.mapping_started {
-            return;
+            return None;
         }
 
         if !self.map_ready.load(Ordering::Acquire) {
-            return; // Not ready yet — will check again next frame.
+            return None; // Not ready yet — will check again next frame.
         }
 
         let data = self.staging_buffer.slice(..).get_mapped_range();
-        let values: &[u32] = bytemuck::cast_slice(&data[..12]);
+        let values: &[u32] = bytemuck::cast_slice(&data[..16]);
         self.result = CollisionResult {
             hit: values[0] != 0,
             normal: [f32::from_bits(values[1]), f32::from_bits(values[2])],
+            impact_t: f32::from_bits(values[3]).clamp(0.0, 1.0),
         };
+        let result = self.result;
         drop(data);
         self.staging_buffer.unmap();
 
         self.pending_readback = false;
         self.mapping_started = false;
+        Some(result)
     }
 }
 
@@ -272,6 +290,67 @@ impl CollisionDetector {
 mod tests {
     use super::*;
     use crate::gpu_test_utils as gpu;
+
+    fn make_terrain_tile(
+        device: &wgpu::Device,
+        terrain_width: u32,
+        terrain_height: u32,
+        solid_cells: &[(u32, u32)],
+    ) -> crate::level_manager::TerrainTile {
+        let mut terrain_data = vec![0i32; (terrain_width * terrain_height) as usize];
+        for &(x, y) in solid_cells {
+            if x < terrain_width && y < terrain_height {
+                terrain_data[(y * terrain_width + x) as usize] = 1000;
+            }
+        }
+        let terrain_buffer = crate::buffer_util::SizedBuffer {
+            buffer: device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Test terrain"),
+                contents: bytemuck::cast_slice(&terrain_data),
+                usage: wgpu::BufferUsages::STORAGE,
+            }),
+            size: (terrain_data.len() * 4) as u64,
+        };
+        crate::level_manager::TerrainTile {
+            shape: crate::level_manager::Interval {
+                start: 0,
+                end: terrain_height as i32,
+            },
+            buffer: terrain_buffer,
+        }
+    }
+
+    fn run_collision(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        ship: &crate::ship::ShipState,
+        prev_ship: &crate::ship::ShipState,
+        terrain_tile: &crate::level_manager::TerrainTile,
+        terrain_width: u32,
+    ) -> CollisionResult {
+        let mut detector = CollisionDetector::init(device);
+        let mut belt = wgpu::util::StagingBelt::new(device.clone(), 256);
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        assert!(detector.dispatch(
+            device,
+            &mut encoder,
+            &mut belt,
+            ship,
+            prev_ship,
+            terrain_tile,
+            terrain_width,
+        ));
+        belt.finish();
+        queue.submit(Some(encoder.finish()));
+        belt.recall();
+
+        detector.start_readback();
+        device.poll(wgpu::PollType::wait_indefinitely()).ok();
+        detector
+            .poll_result()
+            .expect("collision readback should complete after polling")
+    }
 
     /// Run the full dispatch → submit → start_readback → poll_result cycle.
     /// This catches the WASM bug where poll_result tried to read the staging
@@ -285,25 +364,9 @@ mod tests {
 
         let mut detector = CollisionDetector::init(&device);
 
-        // Create a minimal empty terrain buffer (ship in empty space = no collision).
         let terrain_width = 64u32;
         let terrain_height = 64u32;
-        let terrain_data = vec![0i32; (terrain_width * terrain_height) as usize];
-        let terrain_buffer = crate::buffer_util::SizedBuffer {
-            buffer: device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("Test terrain"),
-                contents: bytemuck::cast_slice(&terrain_data),
-                usage: wgpu::BufferUsages::STORAGE,
-            }),
-            size: (terrain_data.len() * 4) as u64,
-        };
-        let terrain_tile = crate::level_manager::TerrainTile {
-            shape: crate::level_manager::Interval {
-                start: 0,
-                end: terrain_height as i32,
-            },
-            buffer: terrain_buffer,
-        };
+        let terrain_tile = make_terrain_tile(&device, terrain_width, terrain_height, &[]);
 
         let ship = crate::ship::ShipState {
             position: [32.0, 32.0],
@@ -314,7 +377,7 @@ mod tests {
         let mut belt = wgpu::util::StagingBelt::new(device.clone(), 256);
         let mut encoder =
             device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-        detector.dispatch(
+        let dispatched = detector.dispatch(
             &device,
             &mut encoder,
             &mut belt,
@@ -323,6 +386,7 @@ mod tests {
             &terrain_tile,
             terrain_width,
         );
+        assert!(dispatched);
 
         // Phase 2: submit GPU work.
         belt.finish();
@@ -338,13 +402,58 @@ mod tests {
         // Drive callbacks before polling — in production this happens via the
         // device.poll(Poll) call in the render loop after queue.submit().
         device.poll(wgpu::PollType::wait_indefinitely()).ok();
-        detector.poll_result();
+        let result = detector.poll_result();
         assert!(!detector.pending_readback, "Readback should have completed");
 
         // Ship in empty terrain → no collision.
+        assert!(result.is_some());
         assert!(
             !detector.result.hit,
             "No collision expected in empty terrain"
         );
+        assert_eq!(detector.result.impact_t, 1.0);
+    }
+
+    #[test]
+    fn collision_reports_impact_time_for_swept_point() {
+        let Some((device, queue)) = gpu::try_create_headless_device() else {
+            eprintln!(
+                "No GPU adapter available — skipping collision_reports_impact_time_for_swept_point"
+            );
+            return;
+        };
+
+        let terrain_width = 64u32;
+        let terrain_height = 64u32;
+        // With orientation 0, the nose sits at local (12, 0). Moving the ship
+        // center from y=20 to y=50 crosses solid cell y=35 at t=0.5.
+        let terrain_tile = make_terrain_tile(&device, terrain_width, terrain_height, &[(44, 35)]);
+        let prev_ship = crate::ship::ShipState {
+            position: [32.0, 20.0],
+            orientation: 0.0,
+            ..Default::default()
+        };
+        let ship = crate::ship::ShipState {
+            position: [32.0, 50.0],
+            orientation: 0.0,
+            ..Default::default()
+        };
+
+        let result = run_collision(
+            &device,
+            &queue,
+            &ship,
+            &prev_ship,
+            &terrain_tile,
+            terrain_width,
+        );
+
+        assert!(result.hit);
+        assert!(
+            (result.impact_t - 0.5).abs() < 0.001,
+            "expected impact_t near 0.5, got {:?}",
+            result
+        );
+        assert_eq!(result.normal, [0.0, -1.0]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,41 @@ struct GameState {
     explosion_pending: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct PendingCollisionSegment {
+    prev_ship: ship::ShipState,
+    next_ship: ship::ShipState,
+}
+
+impl PendingCollisionSegment {
+    fn ship_at(&self, t: f32) -> ship::ShipState {
+        let t = t.clamp(0.0, 1.0);
+        let mut ship = self.next_ship;
+        ship.position = [
+            self.prev_ship.position[0]
+                + (self.next_ship.position[0] - self.prev_ship.position[0]) * t,
+            self.prev_ship.position[1]
+                + (self.next_ship.position[1] - self.prev_ship.position[1]) * t,
+        ];
+        ship
+    }
+}
+
+fn record_collision_motion(
+    pending_segment: &mut Option<PendingCollisionSegment>,
+    prev_ship: ship::ShipState,
+    next_ship: ship::ShipState,
+) {
+    if let Some(segment) = pending_segment {
+        segment.next_ship = next_ship;
+    } else {
+        *pending_segment = Some(PendingCollisionSegment {
+            prev_ship,
+            next_ship,
+        });
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TitleButtonAction {
     Music,
@@ -149,6 +184,8 @@ struct Spout {
     particle_system: particles::ParticleSystem,
     ship_renderer: ship::ShipRenderer,
     collision_detector: collision::CollisionDetector,
+    pending_collision_segment: Option<PendingCollisionSegment>,
+    in_flight_collision_segment: Option<PendingCollisionSegment>,
     background: background::BackgroundRenderer,
     /// Renders into the game view (240x135) — pixel-perfect with terrain/particles.
     game_text: text::TextRenderer,
@@ -405,6 +442,7 @@ impl Spout {
         );
 
         self.collision_detector.result = collision::CollisionResult::default();
+        self.clear_collision_segments();
 
         self.particle_system.set_nozzle_speed(75.0, 75.0);
 
@@ -418,17 +456,19 @@ impl Spout {
     fn start_game(&mut self, device: &wgpu::Device, queue: &wgpu::Queue) {
         let prev_input = self.state.prev_input_state;
         let cur_input = self.state.input_state;
+        let ship_state = ship::ShipState::init(
+            &self.game_params.ship_params,
+            [
+                (self.game_params.viewport_width / 2) as f32 + 0.5,
+                (self.game_params.viewport_height / 2) as f32 + 0.5,
+            ],
+        );
         self.state = GameState {
             mode: GameMode::Playing,
             prev_input_state: prev_input,
             input_state: cur_input,
-            ship_state: ship::ShipState::init(
-                &self.game_params.ship_params,
-                [
-                    (self.game_params.viewport_width / 2) as f32 + 0.5,
-                    (self.game_params.viewport_height / 2) as f32 + 0.5,
-                ],
-            ),
+            ship_state,
+            prev_ship_state: ship_state,
             ..Default::default()
         };
         self.game_time = std::time::Duration::default();
@@ -453,6 +493,7 @@ impl Spout {
         );
 
         self.collision_detector.result = collision::CollisionResult::default();
+        self.clear_collision_segments();
 
         // Restore normal emission speed for gameplay.
         let base_speed = self.game_params.particle_system_params.emission_speed;
@@ -589,11 +630,49 @@ impl Spout {
             .update_state(dt, self.state.viewport_offset, maybe_motion);
     }
 
-    fn update_viewport_height(&mut self) {
-        let ship_height = self.state.ship_state.position[1] as i32;
+    fn clear_collision_segments(&mut self) {
+        self.pending_collision_segment = None;
+        self.in_flight_collision_segment = None;
+    }
+
+    fn commit_score_height(&mut self, height: f32) {
+        let ship_height = height.floor() as i32;
         self.state.score = std::cmp::max(ship_height, self.state.score);
-        self.state.viewport_offset =
-            self.state.score - (self.game_params.viewport_height / 2) as i32;
+    }
+
+    fn update_camera_from_live_ship(&mut self) {
+        let live_height = self.state.ship_state.position[1].floor() as i32;
+        let camera_height = std::cmp::max(live_height, self.state.score);
+        self.state.viewport_offset = camera_height - (self.game_params.viewport_height / 2) as i32;
+    }
+
+    fn resolve_collision_result(&mut self, result: collision::CollisionResult) {
+        let Some(segment) = self.in_flight_collision_segment.take() else {
+            return;
+        };
+
+        if self.state.dead {
+            self.pending_collision_segment = None;
+            return;
+        }
+
+        if result.hit {
+            let impact_ship = segment.ship_at(result.impact_t);
+            self.commit_score_height(impact_ship.position[1]);
+            self.state.prev_ship_state = segment.prev_ship;
+            self.state.ship_state = impact_ship;
+            self.state.dead = true;
+            self.state.explosion_pending = true;
+            self.pending_collision_segment = None;
+            log::info!(
+                "Ship collided with terrain at ({:.0}, {:.0}) t={:.3}",
+                impact_ship.position[0],
+                impact_ship.position[1],
+                result.impact_t
+            );
+        } else {
+            self.commit_score_height(segment.next_ship.position[1]);
+        }
     }
 
     /// Mostly responsible for updating superficial state based on new inputs.
@@ -626,24 +705,23 @@ impl Spout {
                 self.update_particle_system(game_dt, &prev_ship);
             }
             GameMode::Playing => {
-                // Process input state integrated over passage of time.
-                self.state.prev_ship_state = self.state.ship_state;
                 let prev_ship = self.state.ship_state;
-                self.update_ship(game_dt);
 
-                // Poll GPU collision result from last frame (1-frame latency).
-                if !self.state.dead && self.collision_detector.result.hit {
-                    self.state.dead = true;
-                    self.state.explosion_pending = true;
-                    log::info!(
-                        "Ship collided with terrain at ({:.0}, {:.0})",
-                        self.state.ship_state.position[0],
-                        self.state.ship_state.position[1]
-                    );
-                }
-
-                if !self.state.dead {
-                    self.update_viewport_height();
+                // Keep ship and camera motion responsive. Collision readback
+                // confirms score later, or rewinds death to the exact impact.
+                if !self.state.dead && game_dt > 0.0 {
+                    self.state.prev_ship_state = prev_ship;
+                    self.update_ship(game_dt);
+                    if !self.state.dead {
+                        self.update_camera_from_live_ship();
+                        record_collision_motion(
+                            &mut self.pending_collision_segment,
+                            prev_ship,
+                            self.state.ship_state,
+                        );
+                    } else {
+                        self.pending_collision_segment = None;
+                    }
                 }
 
                 self.update_particle_system(game_dt, &prev_ship);
@@ -821,6 +899,8 @@ impl framework::Example for Spout {
             particle_system,
             ship_renderer,
             collision_detector,
+            pending_collision_segment: None,
+            in_flight_collision_segment: None,
             background,
             game_text,
             audio,
@@ -909,9 +989,13 @@ impl framework::Example for Spout {
     ) {
         let cpu_start = Instant::now();
 
-        // Read back GPU collision result from previous frame.
-        if self.state.mode == GameMode::Playing {
-            self.collision_detector.poll_result();
+        // Read back GPU collision result from previous frame. Poll even outside
+        // gameplay so a reset/title transition cannot leave the detector stuck
+        // with a stale in-flight readback.
+        if let Some(result) = self.collision_detector.poll_result() {
+            if self.state.mode == GameMode::Playing {
+                self.resolve_collision_result(result);
+            }
         }
 
         let mut encoder =
@@ -1000,16 +1084,26 @@ impl framework::Example for Spout {
             .run_compute(&self.level_manager, &mut encoder, &mut self.staging_belt);
 
         // Collision detection — only during gameplay.
-        if self.state.mode == GameMode::Playing {
-            self.collision_detector.dispatch(
-                device,
-                &mut encoder,
-                &mut self.staging_belt,
-                &self.state.ship_state,
-                &self.state.prev_ship_state,
-                self.level_manager.terrain_buffer(),
-                self.game_params.level_width,
-            );
+        if self.state.mode == GameMode::Playing
+            && !self.state.dead
+            && self.in_flight_collision_segment.is_none()
+        {
+            if let Some(segment) = self.pending_collision_segment.take() {
+                let dispatched = self.collision_detector.dispatch(
+                    device,
+                    &mut encoder,
+                    &mut self.staging_belt,
+                    &segment.next_ship,
+                    &segment.prev_ship,
+                    self.level_manager.terrain_buffer(),
+                    self.game_params.level_width,
+                );
+                if dispatched {
+                    self.in_flight_collision_segment = Some(segment);
+                } else {
+                    self.pending_collision_segment = Some(segment);
+                }
+            }
         }
 
         // Render background (clears and draws tiled background).
@@ -1224,7 +1318,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::angle_diff;
+    use super::{angle_diff, record_collision_motion, PendingCollisionSegment};
     use std::f32::consts::PI;
 
     fn approx(a: f32, b: f32) -> bool {
@@ -1285,5 +1379,62 @@ mod tests {
                 diff
             );
         }
+    }
+
+    #[test]
+    fn collision_segment_interpolates_position() {
+        let mut prev_ship = spout::ship::ShipState::default();
+        prev_ship.position = [10.0, 20.0];
+        let mut next_ship = prev_ship;
+        next_ship.position = [18.0, 36.0];
+
+        let segment = PendingCollisionSegment {
+            prev_ship,
+            next_ship,
+        };
+        let ship = segment.ship_at(0.25);
+
+        assert!(approx(ship.position[0], 12.0));
+        assert!(approx(ship.position[1], 24.0));
+    }
+
+    #[test]
+    fn collision_segment_clamps_impact_time() {
+        let mut prev_ship = spout::ship::ShipState::default();
+        prev_ship.position = [1.0, 2.0];
+        let mut next_ship = prev_ship;
+        next_ship.position = [3.0, 4.0];
+
+        let segment = PendingCollisionSegment {
+            prev_ship,
+            next_ship,
+        };
+
+        assert!(approx(segment.ship_at(-1.0).position[0], 1.0));
+        assert!(approx(segment.ship_at(2.0).position[1], 4.0));
+    }
+
+    #[test]
+    fn pending_collision_segment_extends_to_latest_motion() {
+        let mut a = spout::ship::ShipState::default();
+        a.position = [0.0, 0.0];
+        let mut b = a;
+        b.position = [1.0, 1.0];
+        let mut c = b;
+        c.position = [2.0, 3.0];
+        let mut d = c;
+        d.position = [4.0, 8.0];
+
+        let mut pending = None;
+        record_collision_motion(&mut pending, a, b);
+        record_collision_motion(&mut pending, b, c);
+        record_collision_motion(&mut pending, c, d);
+
+        let segment = pending.expect("segment");
+
+        assert!(approx(segment.prev_ship.position[0], 0.0));
+        assert!(approx(segment.prev_ship.position[1], 0.0));
+        assert!(approx(segment.next_ship.position[0], 4.0));
+        assert!(approx(segment.next_ship.position[1], 8.0));
     }
 }

--- a/src/shaders/collision.wgsl
+++ b/src/shaders/collision.wgsl
@@ -1,13 +1,14 @@
 // Ship-terrain collision detection with contact normal.
 //
-// For each hull vertex, Bresenham-walks from the previous position to the
-// current position. If a solid cell is hit, records whether the step was
-// horizontal or vertical to produce a bounce normal.
+// Parallelizes over sampled hull points. Each workgroup lane Bresenham-walks
+// one sampled point from the previous position to the current position, then
+// a workgroup reduction picks the earliest hit.
 //
 // Result buffer layout:
 //   [0] = hit (0 or 1)
 //   [1] = normal_x (as u32 bits of f32)
 //   [2] = normal_y (as u32 bits of f32)
+//   [3] = impact_t (as u32 bits of f32; 0.0 previous state, 1.0 current state)
 
 struct CollisionUniforms {
     // Current ship position.
@@ -35,6 +36,13 @@ var<storage, read> terrain_buffer: array<i32>;
 @group(0) @binding(2)
 var<storage, read_write> result: array<u32>;
 
+struct HitInfo {
+    normal: vec2<f32>,
+    t: f32,
+};
+
+const WORKGROUP_SIZE: u32 = 32u;
+
 // Ship hull vertices in local space (matches ship.wgsl outline_vertices).
 // Must stay in sync with the 4-vertex perimeter in ship.wgsl.
 const HULL_VERTS: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
@@ -46,7 +54,12 @@ const HULL_VERTS: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
 
 const NUM_HULL_VERTS: u32 = 4u;
 // Sample hull edges every ~2 world units so no 1-cell gap escapes detection.
-const SAMPLE_STEP: f32 = 2.0;
+// Values are floor(edge length / 2.0), matching the original serial sampler.
+const EDGE_STEPS: array<u32, 4> = array<u32, 4>(10u, 4u, 4u, 10u);
+const NUM_COLLISION_SAMPLES: u32 = 28u;
+
+var<workgroup> sample_t: array<f32, 32>;
+var<workgroup> sample_normal: array<vec2<f32>, 32>;
 
 fn rotate(v: vec2<f32>, angle: f32) -> vec2<f32> {
     let c = cos(angle);
@@ -69,20 +82,43 @@ fn sign_i(v: f32) -> i32 {
     if (v >= 0.0) { return 1; } else { return -1; }
 }
 
+fn no_hit() -> HitInfo {
+    // A real collision at the final endpoint can have t=1.0. Keep no-hit
+    // beyond the valid segment range so reduction still picks endpoint hits.
+    return HitInfo(vec2<f32>(0.0, 0.0), 2.0);
+}
+
+fn fallback_normal(start: vec2<f32>, end: vec2<f32>) -> vec2<f32> {
+    let delta = end - start;
+    if (abs(delta.x) > abs(delta.y)) {
+        if (delta.x >= 0.0) {
+            return vec2<f32>(-1.0, 0.0);
+        }
+        return vec2<f32>(1.0, 0.0);
+    }
+    if (delta.y != 0.0) {
+        if (delta.y >= 0.0) {
+            return vec2<f32>(0.0, -1.0);
+        }
+        return vec2<f32>(0.0, 1.0);
+    }
+    return vec2<f32>(0.0, -1.0);
+}
+
 // Bresenham walk from `start` to `end`. Returns the normal of the first
-// solid cell hit, or (0,0) if no collision.
-fn bresenham_check(start: vec2<f32>, end: vec2<f32>) -> vec2<f32> {
+// solid cell hit and the impact time, or no_hit() if no collision.
+fn bresenham_check(start: vec2<f32>, end: vec2<f32>) -> HitInfo {
     let from_cell = vec2<i32>(floor(start));
     let to_cell = vec2<i32>(floor(end));
     let delta_i = to_cell - from_cell;
     let num_steps = abs(delta_i.x) + abs(delta_i.y);
 
+    if (is_solid(from_cell.x, from_cell.y)) {
+        return HitInfo(fallback_normal(start, end), 0.0);
+    }
+
     if (num_steps == 0) {
-        // Didn't move cells — just check current cell.
-        if (is_solid(to_cell.x, to_cell.y)) {
-            return normalize(start - end);
-        }
-        return vec2<f32>(0.0, 0.0);
+        return no_hit();
     }
 
     let signed_delta = end - start;
@@ -94,6 +130,7 @@ fn bresenham_check(start: vec2<f32>, end: vec2<f32>) -> vec2<f32> {
     var cell = from_cell;
 
     for (var i = 0; i < num_steps; i = i + 1) {
+        let old_cell = cell;
         let err_h = error - delta.y;
         let err_v = error + delta.x;
 
@@ -102,24 +139,28 @@ fn bresenham_check(start: vec2<f32>, end: vec2<f32>) -> vec2<f32> {
             error = err_h;
             cell.x = cell.x + step.x;
             if (is_solid(cell.x, cell.y)) {
-                return vec2<f32>(f32(-step.x), 0.0);
+                let boundary = select(f32(old_cell.x), f32(old_cell.x + 1), step.x > 0);
+                let t = clamp((boundary - start.x) / signed_delta.x, 0.0, 1.0);
+                return HitInfo(vec2<f32>(f32(-step.x), 0.0), t);
             }
         } else {
             // Vertical step.
             error = err_v;
             cell.y = cell.y + step.y;
             if (is_solid(cell.x, cell.y)) {
-                return vec2<f32>(0.0, f32(-step.y));
+                let boundary = select(f32(old_cell.y), f32(old_cell.y + 1), step.y > 0);
+                let t = clamp((boundary - start.y) / signed_delta.y, 0.0, 1.0);
+                return HitInfo(vec2<f32>(0.0, f32(-step.y)), t);
             }
         }
     }
 
-    return vec2<f32>(0.0, 0.0);
+    return no_hit();
 }
 
 // Sweep a single local-space point from its previous world position to its
-// current world position, returning the contact normal (or (0,0) if clear).
-fn check_point(local_pos: vec2<f32>) -> vec2<f32> {
+// current world position, returning hit info if it collides.
+fn check_point(local_pos: vec2<f32>) -> HitInfo {
     let prev_world = rotate(local_pos, uniforms.prev_ship_orientation)
         + vec2<f32>(uniforms.prev_ship_x, uniforms.prev_ship_y);
     let curr_world = rotate(local_pos, uniforms.ship_orientation)
@@ -127,37 +168,66 @@ fn check_point(local_pos: vec2<f32>) -> vec2<f32> {
     return bresenham_check(prev_world, curr_world);
 }
 
-@compute @workgroup_size(1)
-fn main() {
-    var best_normal = vec2<f32>(0.0, 0.0);
+fn edge_sample(edge_index: u32, step_index: u32) -> vec2<f32> {
+    let a = HULL_VERTS[edge_index];
+    let b = HULL_VERTS[(edge_index + 1u) % NUM_HULL_VERTS];
+    let t = f32(step_index) / f32(EDGE_STEPS[edge_index]);
+    return a + (b - a) * t;
+}
 
-    // Check each hull vertex.
-    for (var i = 0u; i < NUM_HULL_VERTS; i = i + 1u) {
-        let n = check_point(HULL_VERTS[i]);
-        if (n.x != 0.0 || n.y != 0.0) {
-            best_normal = n;
-        }
+fn sample_point(sample_index: u32) -> vec2<f32> {
+    if (sample_index < NUM_HULL_VERTS) {
+        return HULL_VERTS[sample_index];
     }
 
-    // Sample each hull edge at ~SAMPLE_STEP world-unit intervals.
-    // This fills the gaps between vertices so thin obstacles aren't missed.
-    for (var i = 0u; i < NUM_HULL_VERTS; i = i + 1u) {
-        let j = (i + 1u) % NUM_HULL_VERTS;
-        let a = HULL_VERTS[i];
-        let b = HULL_VERTS[j];
-        let edge = b - a;
-        let steps = max(1u, u32(length(edge) / SAMPLE_STEP));
-        for (var s = 1u; s < steps; s = s + 1u) {
-            let t = f32(s) / f32(steps);
-            let n = check_point(a + edge * t);
-            if (n.x != 0.0 || n.y != 0.0) {
-                best_normal = n;
+    var remaining = sample_index - NUM_HULL_VERTS;
+    for (var edge = 0u; edge < NUM_HULL_VERTS; edge = edge + 1u) {
+        let interior_samples = EDGE_STEPS[edge] - 1u;
+        if (remaining < interior_samples) {
+            return edge_sample(edge, remaining + 1u);
+        }
+        remaining = remaining - interior_samples;
+    }
+
+    return HULL_VERTS[0];
+}
+
+@compute @workgroup_size(32)
+fn main(@builtin(local_invocation_id) local_id: vec3<u32>) {
+    let lane = local_id.x;
+    var lane_hit = no_hit();
+
+    if (lane < NUM_COLLISION_SAMPLES) {
+        lane_hit = check_point(sample_point(lane));
+    }
+
+    sample_t[lane] = lane_hit.t;
+    sample_normal[lane] = lane_hit.normal;
+    workgroupBarrier();
+
+    var stride = WORKGROUP_SIZE / 2u;
+    loop {
+        if (lane < stride) {
+            let other = lane + stride;
+            if (sample_t[other] < sample_t[lane]) {
+                sample_t[lane] = sample_t[other];
+                sample_normal[lane] = sample_normal[other];
             }
         }
+        workgroupBarrier();
+
+        if (stride == 1u) {
+            break;
+        }
+        stride = stride / 2u;
     }
 
-    let hit = best_normal.x != 0.0 || best_normal.y != 0.0;
-    result[0] = select(0u, 1u, hit);
-    result[1] = bitcast<u32>(best_normal.x);
-    result[2] = bitcast<u32>(best_normal.y);
+    if (lane == 0u) {
+        let best_normal = sample_normal[0];
+        let hit = best_normal.x != 0.0 || best_normal.y != 0.0;
+        result[0] = select(0u, 1u, hit);
+        result[1] = bitcast<u32>(best_normal.x);
+        result[2] = bitcast<u32>(best_normal.y);
+        result[3] = bitcast<u32>(sample_t[0]);
+    }
 }


### PR DESCRIPTION
## Summary
- report impact time from the GPU collision pass and use it to finalize score/death at the exact swept collision point
- keep ship/camera motion responsive while score progress waits for confirmed collision readback
- keep one pending collision segment that extends while a readback is in flight, and reduce hull sample checks in a 32-lane WGSL workgroup

## Tests
- cargo fmt --all -- --check
- cargo test collision --verbose
- cargo clippy -- -D warnings
- cargo test --verbose