### PR TITLE
Add input frame edge helpers

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -73,6 +73,47 @@ mod tests {
     }
 
     #[test]
+    fn input_frame_reports_edges() {
+        let current = InputState {
+            thrust: 1.0,
+            rotate: -1.0,
+            restart: true,
+            touch_started: true,
+            help: true,
+            pause: true,
+            fullscreen: true,
+            ..Default::default()
+        };
+        let frame = InputFrame::new(current, InputState::default());
+
+        assert!(frame.pause_pressed());
+        assert!(frame.fullscreen_pressed());
+        assert!(frame.restart_pressed());
+        assert!(frame.help_pressed());
+        assert!(frame.touch_started());
+        assert!(frame.thrust_started());
+        assert!(frame.rotate_started());
+    }
+
+    #[test]
+    fn input_frame_ignores_held_values() {
+        let current = InputState {
+            thrust: 1.0,
+            rotate: 1.0,
+            pause: true,
+            fullscreen: true,
+            ..Default::default()
+        };
+        let previous = current;
+        let frame = InputFrame::new(current, previous);
+
+        assert!(!frame.pause_pressed());
+        assert!(!frame.fullscreen_pressed());
+        assert!(!frame.thrust_started());
+        assert!(!frame.rotate_started());
+    }
+
+    #[test]
     fn keyboard_thrust() {
         let mut c = InputCollector::default();
         c.held_thrust = true;
@@ -358,6 +399,55 @@ pub struct InputState {
     pub cam_right: bool,
     pub cam_perspective: bool,
     pub cam_reset: bool,
+}
+
+/// Current + previous input snapshots for edge-triggered actions.
+///
+/// This keeps consumers from open-coding `current && !previous` checks, and
+/// gives future menu/gamepad navigation a single place to grow semantic input
+/// intents without changing every screen.
+#[derive(Debug, Copy, Clone, Default)]
+pub struct InputFrame {
+    pub current: InputState,
+    pub previous: InputState,
+}
+
+impl InputFrame {
+    pub fn new(current: InputState, previous: InputState) -> Self {
+        Self { current, previous }
+    }
+
+    pub fn pause_pressed(&self) -> bool {
+        self.current.pause && !self.previous.pause
+    }
+
+    pub fn fullscreen_pressed(&self) -> bool {
+        self.current.fullscreen && !self.previous.fullscreen
+    }
+
+    pub fn restart_pressed(&self) -> bool {
+        self.current.restart && !self.previous.restart
+    }
+
+    pub fn help_pressed(&self) -> bool {
+        self.current.help && !self.previous.help
+    }
+
+    pub fn touch_started(&self) -> bool {
+        self.current.touch_started
+    }
+
+    pub fn pointer_pressed(&self) -> Option<PointerPress> {
+        self.current.pointer_pressed
+    }
+
+    pub fn thrust_started(&self) -> bool {
+        self.current.thrust > 0.0 && self.previous.thrust == 0.0
+    }
+
+    pub fn rotate_started(&self) -> bool {
+        self.current.rotate.abs() > 0.0 && self.previous.rotate.abs() == 0.0
+    }
 }
 
 // --- Touch layout -------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use spout::background;
 use spout::bloom;
 use spout::collision;
 use spout::game_params;
-use spout::input::{InputCollector, InputState};
+use spout::input::{InputCollector, InputFrame, InputState};
 use spout::level_manager;
 use spout::particles;
 use spout::render;
@@ -599,12 +599,12 @@ impl Spout {
 
     /// Window-level / state-agnostic input edges: pause toggle, fullscreen.
     /// Neither needs GPU access.
-    fn handle_global_input(&mut self, window: &winit::window::Window) {
-        if self.input_state.pause && !self.prev_input_state.pause {
+    fn handle_global_input(&mut self, window: &winit::window::Window, input: InputFrame) {
+        if input.pause_pressed() {
             self.toggle_pause();
         }
 
-        if !self.prev_input_state.fullscreen && self.input_state.fullscreen {
+        if input.fullscreen_pressed() {
             if window.fullscreen().is_some() {
                 log::info!("Setting windowed mode.");
                 window.set_fullscreen(None);
@@ -664,14 +664,18 @@ impl Spout {
 
     /// Title-screen input. The screen owns its UI sub-state and reports
     /// high-level actions back to `Spout`.
-    fn process_title_input(&mut self, surface_w: u32, surface_h: u32) -> Option<PendingTransition> {
+    fn process_title_input(
+        &mut self,
+        input: InputFrame,
+        surface_w: u32,
+        surface_h: u32,
+    ) -> Option<PendingTransition> {
         let AppState::Title(title) = &mut self.state else {
             return None;
         };
 
         match title.update(
-            self.input_state,
-            self.prev_input_state,
+            input,
             &self.game_params,
             &self.game_text,
             self.audio.is_playing(),
@@ -695,8 +699,9 @@ impl Spout {
 
         self.prev_input_state = self.input_state;
         self.input_state = self.collector.current_state();
+        let input = InputFrame::new(self.input_state, self.prev_input_state);
 
-        self.handle_global_input(window);
+        self.handle_global_input(window, input);
 
         self.level_manager
             .level_maker
@@ -712,17 +717,17 @@ impl Spout {
         }
 
         self.renderer
-            .update_state(wall_dt, &self.input_state, &self.prev_input_state);
+            .update_state(wall_dt, &input.current, &input.previous);
 
         // Restart from game-over: explicit restart key, or any tap.
-        let restart_pressed = self.input_state.restart
-            || (matches!(self.state, AppState::GameOver { .. }) && self.input_state.touch_started);
+        let restart_pressed = input.restart_pressed()
+            || (matches!(self.state, AppState::GameOver { .. }) && input.touch_started());
         if restart_pressed {
             return Some(PendingTransition::ToTitle);
         }
 
         let win_size = window.inner_size();
-        self.process_title_input(win_size.width, win_size.height)
+        self.process_title_input(input, win_size.width, win_size.height)
     }
 
     fn apply_transition(

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -1,5 +1,5 @@
 use spout::game_params::GameParams;
-use spout::input::{InputState, PointerPress};
+use spout::input::{InputFrame, PointerPress};
 use spout::text::TextRenderer;
 
 #[derive(Debug, Default)]
@@ -48,14 +48,13 @@ struct Button {
 impl TitleScreen {
     pub fn update(
         &mut self,
-        input: InputState,
-        prev_input: InputState,
+        input: InputFrame,
         params: &GameParams,
         text: &TextRenderer,
         music_playing: bool,
         surface_size: (u32, u32),
     ) -> Option<TitleAction> {
-        let clicked_button = input.pointer_pressed.and_then(|point| {
+        let clicked_button = input.pointer_pressed().and_then(|point| {
             self.button_at(
                 point,
                 params,
@@ -67,7 +66,7 @@ impl TitleScreen {
         });
         let mut title_action_handled = false;
 
-        if input.help {
+        if input.help_pressed() {
             self.instructions_open = !self.instructions_open;
             title_action_handled = true;
         }
@@ -82,14 +81,15 @@ impl TitleScreen {
                 }
             }
             title_action_handled = true;
-        } else if self.instructions_open && input.pointer_pressed.is_some() {
+        } else if self.instructions_open && input.pointer_pressed().is_some() {
             self.instructions_open = false;
             title_action_handled = true;
         }
 
-        let new_thrust = input.thrust > 0.0 && prev_input.thrust == 0.0;
-        let new_rotate = input.rotate.abs() > 0.0 && prev_input.rotate.abs() == 0.0;
-        if !title_action_handled && !self.instructions_open && (new_thrust || new_rotate) {
+        if !title_action_handled
+            && !self.instructions_open
+            && (input.thrust_started() || input.rotate_started())
+        {
             return Some(TitleAction::StartGame);
         }
 


### PR DESCRIPTION
## Summary
- add InputFrame to carry current and previous input snapshots
- centralize edge-triggered input helpers for pause, fullscreen, restart, help, touch, thrust, and rotate
- migrate global input and title screen input to use those helpers without changing behavior

## Testing
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test --verbose