### PR TITLE
Add title Play and Menu buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Or try the live demo: [https://glalonde.github.io/spout/](https://glalonde.githu
 
 | Key | Action |
 |-----|--------|
-| W | Thrust |
-| A / D | Rotate |
+| W / Arrow Up | Thrust |
+| A / D / Arrow Left / Arrow Right | Rotate |
 | T | Next track |
 | Y | Toggle music |
 | F | Fullscreen |

--- a/_context/plans/active/near-term.md
+++ b/_context/plans/active/near-term.md
@@ -235,6 +235,9 @@ Tasks:
       sharp and does not glow.
 - [x] Use a bottom-right `X` close button inside the overlay instead of a
       textual close instruction.
+- [x] Replace the title-screen `?` affordance with boxed `PLAY` / `MENU`
+      buttons. `MENU` opens the help overlay, and title buttons support
+      arrow-key focus plus Enter/Space confirmation.
 
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -278,7 +278,13 @@ impl ApplicationHandler for App {
                     .texture
                     .create_view(&wgpu::TextureViewDescriptor::default());
 
-                gpu.spout.render(&view, &gpu.device, &gpu.queue, window);
+                gpu.spout.render(
+                    &view,
+                    &gpu.device,
+                    &gpu.queue,
+                    window,
+                    (gpu.config.width, gpu.config.height),
+                );
                 frame.present();
             }
             event => {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -6,6 +6,7 @@ use spout::ship;
 use spout::text;
 use spout::title_overlay;
 use spout::touch_zone_indicator;
+use spout::ui;
 
 pub(crate) struct Graphics {
     pub(crate) game_view_texture: wgpu::TextureView,
@@ -18,6 +19,7 @@ pub(crate) struct Graphics {
     pub(crate) background: background::BackgroundRenderer,
     /// Renders into the game view (240x135) — pixel-perfect with terrain/particles.
     pub(crate) game_text: text::TextRenderer,
+    pub(crate) ui: ui::UiRenderer,
     pub(crate) staging_belt: wgpu::util::StagingBelt,
     pub(crate) touch_zone_indicator: touch_zone_indicator::TouchZoneIndicator,
     /// Debug overlay: FPS counter rendered at display resolution. Debug builds only.
@@ -82,6 +84,13 @@ impl Graphics {
             text::YDirection::Up,
             text::Font::O4b11,
         );
+        let ui = ui::UiRenderer::new(
+            device,
+            bloom::GAME_VIEW_FORMAT,
+            game_params.viewport_width,
+            game_params.viewport_height,
+            text::YDirection::Up,
+        );
         #[cfg(debug_assertions)]
         let overlay_text = text::TextRenderer::init(
             device,
@@ -116,6 +125,7 @@ impl Graphics {
             ship_renderer,
             background,
             game_text,
+            ui,
             staging_belt,
             touch_zone_indicator,
             #[cfg(debug_assertions)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -78,6 +78,8 @@ mod tests {
         assert!(!state.menu_confirm);
         assert!(!state.menu_cancel);
         assert!(!state.touch_started);
+        assert!(state.pointer_pressed.is_none());
+        assert!(state.pointer_released.is_none());
     }
 
     #[test]
@@ -87,6 +89,8 @@ mod tests {
             rotate: -1.0,
             restart: true,
             touch_started: true,
+            pointer_pressed: Some(PointerPress { x: 12.0, y: 34.0 }),
+            pointer_released: Some(PointerPress { x: 56.0, y: 78.0 }),
             help: true,
             audio_next_track: true,
             audio_toggle: true,
@@ -115,6 +119,8 @@ mod tests {
         assert!(frame.menu_confirm_pressed());
         assert!(frame.menu_cancel_pressed());
         assert!(frame.touch_started());
+        assert!(frame.pointer_pressed().is_some());
+        assert!(frame.pointer_released().is_some());
         assert!(frame.thrust_started());
         assert!(frame.rotate_started());
     }
@@ -166,6 +172,21 @@ mod tests {
         let second = c.current_state();
         assert!(!second.audio_next_track);
         assert!(!second.audio_toggle);
+    }
+
+    #[test]
+    fn pointer_press_and_release_are_one_shot() {
+        let mut c = InputCollector::default();
+        c.pointer_press = Some(PointerPress { x: 12.0, y: 34.0 });
+        c.pointer_release = Some(PointerPress { x: 56.0, y: 78.0 });
+
+        let first = c.current_state();
+        assert_eq!(first.pointer_pressed.map(|point| point.x), Some(12.0));
+        assert_eq!(first.pointer_released.map(|point| point.y), Some(78.0));
+
+        let second = c.current_state();
+        assert!(second.pointer_pressed.is_none());
+        assert!(second.pointer_released.is_none());
     }
 
     #[test]
@@ -234,6 +255,20 @@ mod tests {
             let state = c.current_state();
             assert_eq!(state.thrust, 1.0);
             assert_eq!(state.rotate, 0.0);
+        }
+
+        #[test]
+        fn touch_end_reports_pointer_release_once() {
+            let mut c = touch_collector(200.0, 100.0);
+            c.touch.started(1, 10.0, 50.0);
+            let _ = c.current_state();
+            c.touch.ended(1, 12.0, 52.0);
+
+            let first = c.current_state();
+            assert_eq!(first.pointer_released.map(|point| point.x), Some(12.0));
+
+            let second = c.current_state();
+            assert!(second.pointer_released.is_none());
         }
 
         #[test]
@@ -440,6 +475,7 @@ pub struct InputState {
     pub restart: bool,
     pub touch_started: bool,
     pub pointer_pressed: Option<PointerPress>,
+    pub pointer_released: Option<PointerPress>,
     pub help: bool,
     pub audio_next_track: bool,
     pub audio_toggle: bool,
@@ -538,6 +574,10 @@ impl InputFrame {
         self.current.pointer_pressed
     }
 
+    pub fn pointer_released(&self) -> Option<PointerPress> {
+        self.current.pointer_released
+    }
+
     pub fn thrust_started(&self) -> bool {
         self.current.thrust > 0.0 && self.previous.thrust == 0.0
     }
@@ -591,6 +631,9 @@ struct TouchTracker {
     touch_started: bool,
     touch_started_x: f32,
     touch_started_y: f32,
+    touch_ended: bool,
+    touch_ended_x: f32,
+    touch_ended_y: f32,
     /// Sticky "any touch event has occurred this session" flag — used to
     /// detect that the player is on a touch device so we can show the
     /// touch-zone hint. Never resets after the first touch.
@@ -636,7 +679,10 @@ impl TouchTracker {
         }
     }
 
-    fn ended(&mut self, id: TouchId) {
+    fn ended(&mut self, id: TouchId, x: f32, y: f32) {
+        self.touch_ended = true;
+        self.touch_ended_x = x;
+        self.touch_ended_y = y;
         if Some(id) == self.thrust_id {
             self.thrust_id = None;
         }
@@ -646,6 +692,19 @@ impl TouchTracker {
             self.rotate_anchor_y = 0.0;
             self.rotate_x = 0.0;
             self.rotate_y = 0.0;
+        }
+    }
+
+    fn consume_touch_ended(&mut self) -> Option<PointerPress> {
+        let ended = self.touch_ended;
+        self.touch_ended = false;
+        if ended {
+            Some(PointerPress {
+                x: self.touch_ended_x,
+                y: self.touch_ended_y,
+            })
+        } else {
+            None
         }
     }
 
@@ -729,6 +788,7 @@ pub struct InputCollector {
     held_menu_confirm: bool,
     held_menu_cancel: bool,
     pointer_press: Option<PointerPress>,
+    pointer_release: Option<PointerPress>,
     cursor_x: f32,
     cursor_y: f32,
 
@@ -770,6 +830,7 @@ impl Default for InputCollector {
             held_menu_confirm: false,
             held_menu_cancel: false,
             pointer_press: None,
+            pointer_release: None,
             cursor_x: 0.0,
             cursor_y: 0.0,
             touch_scheme: TouchControlScheme::Drag,
@@ -885,7 +946,11 @@ impl InputCollector {
                 let changed = event.changed_touches();
                 for i in 0..changed.length() {
                     if let Some(touch) = changed.get(i) {
-                        s.ended(i64::from(touch.identifier()));
+                        s.ended(
+                            i64::from(touch.identifier()),
+                            touch.client_x() as f32,
+                            touch.client_y() as f32,
+                        );
                     }
                 }
             });
@@ -964,6 +1029,15 @@ impl InputCollector {
                     y: self.cursor_y,
                 });
             }
+            winit::event::WindowEvent::MouseInput { state, button, .. }
+                if *state == winit::event::ElementState::Released
+                    && *button == winit::event::MouseButton::Left =>
+            {
+                self.pointer_release = Some(PointerPress {
+                    x: self.cursor_x,
+                    y: self.cursor_y,
+                });
+            }
             _ => {}
         }
 
@@ -978,11 +1052,10 @@ impl InputCollector {
             let id = touch.id as i64;
             match touch.phase {
                 TouchPhase::Started => {
-                    self.pointer_press = Some(PointerPress { x, y });
                     self.touch.started(id, x, y);
                 }
                 TouchPhase::Moved => self.touch.moved(id, x, y),
-                TouchPhase::Ended | TouchPhase::Cancelled => self.touch.ended(id),
+                TouchPhase::Ended | TouchPhase::Cancelled => self.touch.ended(id, x, y),
             }
         }
     }
@@ -997,6 +1070,7 @@ impl InputCollector {
         let audio_toggle = self.audio_toggle_requested;
         self.audio_toggle_requested = false;
         let mut pointer_pressed = self.pointer_press.take();
+        let mut pointer_released = self.pointer_release.take();
 
         let keyboard_thrust = if self.held_thrust { 1.0 } else { 0.0 };
         let keyboard_rotate = match (self.held_left, self.held_right) {
@@ -1011,6 +1085,10 @@ impl InputCollector {
             if pointer_pressed.is_none() {
                 pointer_pressed = touch_press;
             }
+            let touch_release = self.touch.consume_touch_ended();
+            if pointer_released.is_none() {
+                pointer_released = touch_release;
+            }
             let touch_started = touch_press.is_some();
             let touch_input = self.touch.current_input(self.touch_scheme);
             (touch_started, touch_input)
@@ -1022,6 +1100,10 @@ impl InputCollector {
             let touch_press = touch.consume_touch_started();
             if pointer_pressed.is_none() {
                 pointer_pressed = touch_press;
+            }
+            let touch_release = touch.consume_touch_ended();
+            if pointer_released.is_none() {
+                pointer_released = touch_release;
             }
             let touch_started = touch_press.is_some();
             let touch_input = touch.current_input(self.touch_scheme);
@@ -1048,6 +1130,7 @@ impl InputCollector {
             restart,
             touch_started,
             pointer_pressed,
+            pointer_released,
             help,
             audio_next_track,
             audio_toggle,

--- a/src/input.rs
+++ b/src/input.rs
@@ -190,6 +190,18 @@ mod tests {
     }
 
     #[test]
+    fn css_touch_position_maps_to_backing_pixels() {
+        let point =
+            css_to_surface_point((110.0, 65.0), (10.0, 15.0), (200.0, 100.0), (400.0, 300.0))
+                .expect("inside canvas rect");
+
+        assert_eq!(point.x, 200.0);
+        assert_eq!(point.y, 150.0);
+        assert_eq!(point.surface_width, 400.0);
+        assert_eq!(point.surface_height, 300.0);
+    }
+
+    #[test]
     fn keyboard_thrust() {
         let mut c = InputCollector::default();
         c.held_thrust = true;
@@ -891,18 +903,16 @@ impl InputCollector {
             let canvas_ref = canvas.clone();
             let cb = Closure::<dyn FnMut(_)>::new(move |event: web_sys::TouchEvent| {
                 event.prevent_default();
-                let canvas_width = canvas_ref.client_width() as f32;
-                let canvas_height = canvas_ref.client_height() as f32;
                 let mut s = state.borrow_mut();
-                s.set_surface_width(canvas_width);
-                s.set_surface_height(canvas_height);
                 let changed = event.changed_touches();
                 for i in 0..changed.length() {
                     if let Some(touch) = changed.get(i) {
-                        let x = touch.client_x() as f32;
-                        let y = touch.client_y() as f32;
-                        let id = touch.identifier();
-                        s.started(i64::from(id), x, y);
+                        let Some(point) = canvas_touch_point(&canvas_ref, &touch) else {
+                            continue;
+                        };
+                        s.set_surface_width(point.surface_width);
+                        s.set_surface_height(point.surface_height);
+                        s.started(i64::from(touch.identifier()), point.x, point.y);
                     }
                 }
             });
@@ -916,17 +926,17 @@ impl InputCollector {
         // touchmove: update rotate_x if the rotate touch moved.
         {
             let state = std::rc::Rc::clone(&self.wasm_touch);
+            let canvas_ref = canvas.clone();
             let cb = Closure::<dyn FnMut(_)>::new(move |event: web_sys::TouchEvent| {
                 event.prevent_default();
                 let mut s = state.borrow_mut();
                 let changed = event.changed_touches();
                 for i in 0..changed.length() {
                     if let Some(touch) = changed.get(i) {
-                        s.moved(
-                            i64::from(touch.identifier()),
-                            touch.client_x() as f32,
-                            touch.client_y() as f32,
-                        );
+                        let Some(point) = canvas_touch_point(&canvas_ref, &touch) else {
+                            continue;
+                        };
+                        s.moved(i64::from(touch.identifier()), point.x, point.y);
                     }
                 }
             });
@@ -940,17 +950,17 @@ impl InputCollector {
         // touchend + touchcancel: release whichever zone(s) ended.
         {
             let state = std::rc::Rc::clone(&self.wasm_touch);
+            let canvas_ref = canvas.clone();
             let cb = Closure::<dyn FnMut(_)>::new(move |event: web_sys::TouchEvent| {
                 event.prevent_default();
                 let mut s = state.borrow_mut();
                 let changed = event.changed_touches();
                 for i in 0..changed.length() {
                     if let Some(touch) = changed.get(i) {
-                        s.ended(
-                            i64::from(touch.identifier()),
-                            touch.client_x() as f32,
-                            touch.client_y() as f32,
-                        );
+                        let Some(point) = canvas_touch_point(&canvas_ref, &touch) else {
+                            continue;
+                        };
+                        s.ended(i64::from(touch.identifier()), point.x, point.y);
                     }
                 }
             });
@@ -1152,4 +1162,56 @@ impl InputCollector {
             cam_reset: self.held_cam_reset,
         }
     }
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+struct CanvasTouchPoint {
+    x: f32,
+    y: f32,
+    surface_width: f32,
+    surface_height: f32,
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+fn css_to_surface_point(
+    client: (f64, f64),
+    rect_origin: (f64, f64),
+    css_size: (f64, f64),
+    surface_size: (f64, f64),
+) -> Option<CanvasTouchPoint> {
+    let (css_width, css_height) = css_size;
+    if css_width <= 0.0 || css_height <= 0.0 {
+        return None;
+    }
+
+    let (surface_width, surface_height) = surface_size;
+    let surface_width = surface_width.max(1.0);
+    let surface_height = surface_height.max(1.0);
+    let (client_x, client_y) = client;
+    let (rect_left, rect_top) = rect_origin;
+    let x = (client_x - rect_left) * surface_width / css_width;
+    let y = (client_y - rect_top) * surface_height / css_height;
+
+    Some(CanvasTouchPoint {
+        x: x as f32,
+        y: y as f32,
+        surface_width: surface_width as f32,
+        surface_height: surface_height as f32,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn canvas_touch_point(
+    canvas: &web_sys::HtmlCanvasElement,
+    touch: &web_sys::Touch,
+) -> Option<CanvasTouchPoint> {
+    let rect = canvas.get_bounding_client_rect();
+    let css_width = rect.width();
+    let css_height = rect.height();
+    css_to_surface_point(
+        (f64::from(touch.client_x()), f64::from(touch.client_y())),
+        (rect.left(), rect.top()),
+        (css_width, css_height),
+        (f64::from(canvas.width()), f64::from(canvas.height())),
+    )
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -227,11 +227,56 @@ mod tests {
     }
 
     #[test]
+    fn keyboard_arrow_thrust() {
+        let mut c = InputCollector::default();
+        c.held_arrow_thrust = true;
+        let state = c.current_state();
+        assert_eq!(state.thrust, 1.0);
+        assert_eq!(state.rotate, 0.0);
+    }
+
+    #[test]
+    fn keyboard_arrow_rotate_left() {
+        let mut c = InputCollector::default();
+        c.held_arrow_left = true;
+        let state = c.current_state();
+        assert_eq!(state.thrust, 0.0);
+        assert_eq!(state.rotate, 1.0);
+    }
+
+    #[test]
+    fn keyboard_arrow_rotate_right() {
+        let mut c = InputCollector::default();
+        c.held_arrow_right = true;
+        assert_eq!(c.current_state().rotate, -1.0);
+    }
+
+    #[test]
     fn keyboard_left_and_right_cancel() {
         let mut c = InputCollector::default();
         c.held_left = true;
         c.held_right = true;
         assert_eq!(c.current_state().rotate, 0.0);
+    }
+
+    #[test]
+    fn keyboard_alternate_thrust_bindings_are_independent() {
+        let mut c = InputCollector::default();
+        c.held_thrust = true;
+        c.held_arrow_thrust = true;
+
+        c.held_thrust = false;
+        assert_eq!(c.current_state().thrust, 1.0);
+    }
+
+    #[test]
+    fn keyboard_alternate_rotate_bindings_are_independent() {
+        let mut c = InputCollector::default();
+        c.held_left = true;
+        c.held_arrow_left = true;
+
+        c.held_left = false;
+        assert_eq!(c.current_state().rotate, 1.0);
     }
 
     #[test]
@@ -779,6 +824,9 @@ pub struct InputCollector {
     held_thrust: bool,
     held_left: bool,
     held_right: bool,
+    held_arrow_thrust: bool,
+    held_arrow_left: bool,
+    held_arrow_right: bool,
     held_pause: bool,
     held_fullscreen: bool,
     held_cam_in: bool,
@@ -821,6 +869,9 @@ impl Default for InputCollector {
             held_thrust: false,
             held_left: false,
             held_right: false,
+            held_arrow_thrust: false,
+            held_arrow_left: false,
+            held_arrow_right: false,
             held_pause: false,
             held_fullscreen: false,
             held_cam_in: false,
@@ -1014,10 +1065,19 @@ impl InputCollector {
                 KeyCode::KeyY if pressed => self.audio_toggle_requested = true,
 
                 // Menu navigation
-                KeyCode::ArrowUp => self.held_menu_up = pressed,
+                KeyCode::ArrowUp => {
+                    self.held_arrow_thrust = pressed;
+                    self.held_menu_up = pressed;
+                }
                 KeyCode::ArrowDown => self.held_menu_down = pressed,
-                KeyCode::ArrowLeft => self.held_menu_left = pressed,
-                KeyCode::ArrowRight => self.held_menu_right = pressed,
+                KeyCode::ArrowLeft => {
+                    self.held_arrow_left = pressed;
+                    self.held_menu_left = pressed;
+                }
+                KeyCode::ArrowRight => {
+                    self.held_arrow_right = pressed;
+                    self.held_menu_right = pressed;
+                }
                 KeyCode::Enter | KeyCode::Space => self.held_menu_confirm = pressed,
                 KeyCode::Escape => self.held_menu_cancel = pressed,
 
@@ -1082,8 +1142,14 @@ impl InputCollector {
         let mut pointer_pressed = self.pointer_press.take();
         let mut pointer_released = self.pointer_release.take();
 
-        let keyboard_thrust = if self.held_thrust { 1.0 } else { 0.0 };
-        let keyboard_rotate = match (self.held_left, self.held_right) {
+        let keyboard_thrust = if self.held_thrust || self.held_arrow_thrust {
+            1.0
+        } else {
+            0.0
+        };
+        let keyboard_left = self.held_left || self.held_arrow_left;
+        let keyboard_right = self.held_right || self.held_arrow_right;
+        let keyboard_rotate = match (keyboard_left, keyboard_right) {
             (true, false) => 1.0,
             (false, true) => -1.0,
             _ => 0.0,

--- a/src/input.rs
+++ b/src/input.rs
@@ -71,6 +71,12 @@ mod tests {
         assert!(!state.restart);
         assert!(!state.audio_next_track);
         assert!(!state.audio_toggle);
+        assert!(!state.menu_up);
+        assert!(!state.menu_down);
+        assert!(!state.menu_left);
+        assert!(!state.menu_right);
+        assert!(!state.menu_confirm);
+        assert!(!state.menu_cancel);
         assert!(!state.touch_started);
     }
 
@@ -84,6 +90,12 @@ mod tests {
             help: true,
             audio_next_track: true,
             audio_toggle: true,
+            menu_up: true,
+            menu_down: true,
+            menu_left: true,
+            menu_right: true,
+            menu_confirm: true,
+            menu_cancel: true,
             pause: true,
             fullscreen: true,
             ..Default::default()
@@ -96,6 +108,12 @@ mod tests {
         assert!(frame.help_pressed());
         assert!(frame.audio_next_track_pressed());
         assert!(frame.audio_toggle_pressed());
+        assert!(frame.menu_up_pressed());
+        assert!(frame.menu_down_pressed());
+        assert!(frame.menu_left_pressed());
+        assert!(frame.menu_right_pressed());
+        assert!(frame.menu_confirm_pressed());
+        assert!(frame.menu_cancel_pressed());
         assert!(frame.touch_started());
         assert!(frame.thrust_started());
         assert!(frame.rotate_started());
@@ -110,6 +128,12 @@ mod tests {
             fullscreen: true,
             audio_next_track: true,
             audio_toggle: true,
+            menu_up: true,
+            menu_down: true,
+            menu_left: true,
+            menu_right: true,
+            menu_confirm: true,
+            menu_cancel: true,
             ..Default::default()
         };
         let previous = current;
@@ -119,6 +143,12 @@ mod tests {
         assert!(!frame.fullscreen_pressed());
         assert!(!frame.audio_next_track_pressed());
         assert!(!frame.audio_toggle_pressed());
+        assert!(!frame.menu_up_pressed());
+        assert!(!frame.menu_down_pressed());
+        assert!(!frame.menu_left_pressed());
+        assert!(!frame.menu_right_pressed());
+        assert!(!frame.menu_confirm_pressed());
+        assert!(!frame.menu_cancel_pressed());
         assert!(!frame.thrust_started());
         assert!(!frame.rotate_started());
     }
@@ -417,6 +447,14 @@ pub struct InputState {
     pub pause: bool,
     pub fullscreen: bool,
 
+    // Menu controls (keyboard/gamepad-style, edge-triggered by InputFrame):
+    pub menu_up: bool,
+    pub menu_down: bool,
+    pub menu_left: bool,
+    pub menu_right: bool,
+    pub menu_confirm: bool,
+    pub menu_cancel: bool,
+
     // Camera controls (debug, keyboard-only):
     pub cam_in: bool,
     pub cam_out: bool,
@@ -466,6 +504,30 @@ impl InputFrame {
 
     pub fn audio_toggle_pressed(&self) -> bool {
         self.current.audio_toggle && !self.previous.audio_toggle
+    }
+
+    pub fn menu_up_pressed(&self) -> bool {
+        self.current.menu_up && !self.previous.menu_up
+    }
+
+    pub fn menu_down_pressed(&self) -> bool {
+        self.current.menu_down && !self.previous.menu_down
+    }
+
+    pub fn menu_left_pressed(&self) -> bool {
+        self.current.menu_left && !self.previous.menu_left
+    }
+
+    pub fn menu_right_pressed(&self) -> bool {
+        self.current.menu_right && !self.previous.menu_right
+    }
+
+    pub fn menu_confirm_pressed(&self) -> bool {
+        self.current.menu_confirm && !self.previous.menu_confirm
+    }
+
+    pub fn menu_cancel_pressed(&self) -> bool {
+        self.current.menu_cancel && !self.previous.menu_cancel
     }
 
     pub fn touch_started(&self) -> bool {
@@ -660,6 +722,12 @@ pub struct InputCollector {
     help_requested: bool,
     audio_next_track_requested: bool,
     audio_toggle_requested: bool,
+    held_menu_up: bool,
+    held_menu_down: bool,
+    held_menu_left: bool,
+    held_menu_right: bool,
+    held_menu_confirm: bool,
+    held_menu_cancel: bool,
     pointer_press: Option<PointerPress>,
     cursor_x: f32,
     cursor_y: f32,
@@ -695,6 +763,12 @@ impl Default for InputCollector {
             help_requested: false,
             audio_next_track_requested: false,
             audio_toggle_requested: false,
+            held_menu_up: false,
+            held_menu_down: false,
+            held_menu_left: false,
+            held_menu_right: false,
+            held_menu_confirm: false,
+            held_menu_cancel: false,
             pointer_press: None,
             cursor_x: 0.0,
             cursor_y: 0.0,
@@ -864,6 +938,14 @@ impl InputCollector {
                 KeyCode::KeyT if pressed => self.audio_next_track_requested = true,
                 KeyCode::KeyY if pressed => self.audio_toggle_requested = true,
 
+                // Menu navigation
+                KeyCode::ArrowUp => self.held_menu_up = pressed,
+                KeyCode::ArrowDown => self.held_menu_down = pressed,
+                KeyCode::ArrowLeft => self.held_menu_left = pressed,
+                KeyCode::ArrowRight => self.held_menu_right = pressed,
+                KeyCode::Enter | KeyCode::Space => self.held_menu_confirm = pressed,
+                KeyCode::Escape => self.held_menu_cancel = pressed,
+
                 _ => {}
             }
         }
@@ -971,6 +1053,12 @@ impl InputCollector {
             audio_toggle,
             pause: self.held_pause,
             fullscreen: self.held_fullscreen,
+            menu_up: self.held_menu_up,
+            menu_down: self.held_menu_down,
+            menu_left: self.held_menu_left,
+            menu_right: self.held_menu_right,
+            menu_confirm: self.held_menu_confirm,
+            menu_cancel: self.held_menu_cancel,
             cam_in: self.held_cam_in,
             cam_out: self.held_cam_out,
             cam_up: self.held_cam_up,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,4 @@ pub mod text;
 pub mod textured_quad;
 pub mod title_overlay;
 pub mod touch_zone_indicator;
+pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -701,7 +701,11 @@ impl Spout {
     /// Pure-CPU update phase. Snapshots input, ticks time, drives simulation,
     /// applies non-GPU transitions inline (pause toggle, GameOver), and
     /// returns a GPU-bound transition intent (ToTitle / ToPlay) if any.
-    fn update_phase(&mut self, window: &winit::window::Window) -> Option<PendingTransition> {
+    fn update_phase(
+        &mut self,
+        window: &winit::window::Window,
+        surface_size: (u32, u32),
+    ) -> Option<PendingTransition> {
         self.audio.poll();
         self.resolve_pending_collision();
 
@@ -736,8 +740,7 @@ impl Spout {
             return Some(PendingTransition::ToTitle);
         }
 
-        let win_size = window.inner_size();
-        self.process_title_input(input, win_size.width, win_size.height)
+        self.process_title_input(input, surface_size.0, surface_size.1)
     }
 
     fn apply_transition(
@@ -866,9 +869,10 @@ impl Spout {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         window: &winit::window::Window,
+        surface_size: (u32, u32),
     ) {
         let cpu_start = Instant::now();
-        let pending = self.update_phase(window);
+        let pending = self.update_phase(window, surface_size);
         if let Some(t) = pending {
             self.apply_transition(t, device, queue);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use spout::scoring;
 use spout::ship;
 
 use graphics::Graphics;
-use screens::title::{TitleAction, TitleRenderFlags, TitleScreen};
+use screens::title::{TitleAction, TitleRenderFlags, TitleScreen, TitleUiRenderContext};
 
 /// Shortest signed angular distance from `current` to `target`, in [-π, π].
 fn angle_diff(target: f32, current: f32) -> f32 {
@@ -959,24 +959,18 @@ impl Spout {
             .render(&self.graphics.game_view_texture, &mut encoder);
 
         if let AppState::Title(title) = &self.state {
-            title.draw_help_button(
+            title.prepare_ui(TitleUiRenderContext {
                 device,
-                &mut encoder,
-                &self.graphics.game_view_texture,
-                &self.game_params,
-                &self.graphics.game_text,
-            );
-            title.prepare_ui(
-                device,
-                &mut encoder,
-                &self.graphics.title_ui_view,
-                &self.game_params,
-                &self.graphics.game_text,
-                TitleRenderFlags {
+                encoder: &mut encoder,
+                title_ui_view: &self.graphics.title_ui_view,
+                ui: &self.graphics.ui,
+                params: &self.game_params,
+                text: &self.graphics.game_text,
+                flags: TitleRenderFlags {
                     music_playing: self.audio.is_playing(),
                     using_touch: self.collector.has_been_touched() || tap_restart_prompt(),
                 },
-            );
+            });
         }
 
         // Ship — only during active gameplay or pause.

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -62,7 +62,8 @@ impl TitleScreen {
         music_playing: bool,
         surface_size: (u32, u32),
     ) -> Option<TitleAction> {
-        let clicked_button = input.pointer_pressed().and_then(|point| {
+        let pointer_pressed = input.pointer_pressed();
+        let clicked_button = pointer_pressed.and_then(|point| {
             self.button_at(
                 point,
                 params,
@@ -81,8 +82,10 @@ impl TitleScreen {
         if let Some(action) = clicked_button {
             self.focused_button = action;
             return self.activate_button(action);
-        } else if self.instructions_open && input.pointer_pressed().is_some() {
-            self.close_menu();
+        } else if pointer_pressed.is_some() {
+            if self.instructions_open {
+                self.close_menu();
+            }
             return None;
         }
 

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -13,6 +13,8 @@ const BUTTON_LABEL_H: f32 = 12.0;
 pub struct TitleScreen {
     instructions_open: bool,
     focused_button: ButtonAction,
+    pressed_button: Option<ButtonAction>,
+    focus_visible: bool,
 }
 
 impl Default for TitleScreen {
@@ -20,6 +22,8 @@ impl Default for TitleScreen {
         Self {
             instructions_open: false,
             focused_button: ButtonAction::Play,
+            pressed_button: None,
+            focus_visible: true,
         }
     }
 }
@@ -62,30 +66,46 @@ impl TitleScreen {
         music_playing: bool,
         surface_size: (u32, u32),
     ) -> Option<TitleAction> {
+        if input.help_pressed() {
+            self.focus_visible = true;
+            self.pressed_button = None;
+            self.toggle_menu();
+            return None;
+        }
+
         let pointer_pressed = input.pointer_pressed();
-        let clicked_button = pointer_pressed.and_then(|point| {
-            self.button_at(
+        if let Some(point) = pointer_pressed {
+            self.focus_visible = false;
+            self.pressed_button = self.button_at(
                 point,
                 params,
                 text,
                 music_playing,
                 surface_size.0,
                 surface_size.1,
-            )
-        });
+            );
+        }
 
-        if input.help_pressed() {
-            self.toggle_menu();
+        if let Some(point) = input.pointer_released() {
+            self.focus_visible = false;
+            let pressed_button = self.pressed_button.take();
+            let released_button = self.button_at(
+                point,
+                params,
+                text,
+                music_playing,
+                surface_size.0,
+                surface_size.1,
+            );
+            if let (Some(pressed), Some(released)) = (pressed_button, released_button) {
+                if pressed == released {
+                    return self.activate_button(released);
+                }
+            }
             return None;
         }
 
-        if let Some(action) = clicked_button {
-            self.focused_button = action;
-            return self.activate_button(action);
-        } else if pointer_pressed.is_some() {
-            if self.instructions_open {
-                self.close_menu();
-            }
+        if pointer_pressed.is_some() {
             return None;
         }
 
@@ -93,6 +113,7 @@ impl TitleScreen {
         self.ensure_focus_visible(&buttons);
 
         if input.menu_cancel_pressed() && self.instructions_open {
+            self.focus_visible = true;
             self.close_menu();
             return None;
         }
@@ -102,6 +123,7 @@ impl TitleScreen {
         }
 
         if input.menu_confirm_pressed() {
+            self.focus_visible = true;
             return self.activate_button(self.focused_button);
         }
 
@@ -153,7 +175,7 @@ impl TitleScreen {
             let label_x =
                 button.rect.x + (button.rect.w - ctx.text.text_width(button.label, scale)) / 2.0;
             let label_y = button.rect.y + (button.rect.h - BUTTON_LABEL_H) / 2.0;
-            let color = if button.action == self.focused_button {
+            let color = if self.button_highlighted(button.action) {
                 accent_color
             } else {
                 button_color
@@ -287,6 +309,7 @@ impl TitleScreen {
     }
 
     fn toggle_menu(&mut self) {
+        self.pressed_button = None;
         if self.instructions_open {
             self.close_menu();
         } else {
@@ -296,6 +319,7 @@ impl TitleScreen {
     }
 
     fn close_menu(&mut self) {
+        self.pressed_button = None;
         self.instructions_open = false;
         self.focused_button = ButtonAction::Menu;
     }
@@ -339,24 +363,33 @@ impl TitleScreen {
         } else {
             (current + 1) % buttons.len()
         };
+        self.focus_visible = true;
+        self.pressed_button = None;
         self.focused_button = buttons[next].action;
         true
     }
 
     fn button_style(&self, action: ButtonAction) -> RectStyle {
-        let focused = action == self.focused_button;
+        let pressed = self.pressed_button == Some(action);
+        let focused = self.focus_visible && action == self.focused_button;
         RectStyle {
-            fill_color: if focused {
+            fill_color: if pressed {
+                [0.12, 0.16, 0.16, 0.9]
+            } else if focused {
                 [0.08, 0.12, 0.13, 0.78]
             } else {
                 [0.02, 0.05, 0.07, 0.68]
             },
-            outline_color: if focused {
+            outline_color: if pressed || focused {
                 [0.9, 0.72, 0.48, 1.0]
             } else {
                 [0.45, 0.57, 0.58, 0.92]
             },
-            outline_px: if focused { 2.0 } else { 1.0 },
+            outline_px: if pressed || focused { 2.0 } else { 1.0 },
         }
+    }
+
+    fn button_highlighted(&self, action: ButtonAction) -> bool {
+        self.pressed_button == Some(action) || (self.focus_visible && action == self.focused_button)
     }
 }

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -5,7 +5,7 @@ use spout::ui::{self, RectStyle, UiButton, UiRect, UiRenderer};
 
 const BUTTON_PAD_X: f32 = 8.0;
 const BUTTON_PAD_Y: f32 = 6.0;
-const BUTTON_GAP: f32 = 8.0;
+const BUTTON_GAP: f32 = 32.0;
 const BUTTON_BOTTOM_MARGIN: f32 = 12.0;
 const BUTTON_LABEL_H: f32 = 12.0;
 const BUTTON_SIDE_MARGIN: f32 = 14.0;

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -3,10 +3,10 @@ use spout::input::{InputFrame, PointerPress};
 use spout::text::TextRenderer;
 use spout::ui::{self, RectStyle, UiButton, UiRect, UiRenderer};
 
-const BUTTON_W: f32 = 78.0;
-const BUTTON_H: f32 = 34.0;
+const BUTTON_W: f32 = 96.0;
+const BUTTON_H: f32 = 44.0;
 const BUTTON_GAP: f32 = 12.0;
-const BUTTON_BOTTOM_MARGIN: f32 = 14.0;
+const BUTTON_BOTTOM_MARGIN: f32 = 10.0;
 const BUTTON_LABEL_H: f32 = 12.0;
 
 #[derive(Debug)]
@@ -103,10 +103,6 @@ impl TitleScreen {
 
         if input.menu_confirm_pressed() {
             return self.activate_button(self.focused_button);
-        }
-
-        if !self.instructions_open && (input.thrust_started() || input.rotate_started()) {
-            return Some(TitleAction::StartGame);
         }
 
         None
@@ -206,7 +202,7 @@ impl TitleScreen {
             } else {
                 "MUSIC OFF"
             };
-            let music_w = (text.text_width(music_label, 1.0) + 18.0).max(96.0);
+            let music_w = (text.text_width(music_label, 1.0) + 22.0).max(112.0);
             return vec![
                 UiButton {
                     action: ButtonAction::Music,

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -3,11 +3,12 @@ use spout::input::{InputFrame, PointerPress};
 use spout::text::TextRenderer;
 use spout::ui::{self, RectStyle, UiButton, UiRect, UiRenderer};
 
-const BUTTON_W: f32 = 96.0;
-const BUTTON_H: f32 = 44.0;
-const BUTTON_GAP: f32 = 12.0;
-const BUTTON_BOTTOM_MARGIN: f32 = 10.0;
+const BUTTON_PAD_X: f32 = 8.0;
+const BUTTON_PAD_Y: f32 = 6.0;
+const BUTTON_GAP: f32 = 8.0;
+const BUTTON_BOTTOM_MARGIN: f32 = 12.0;
 const BUTTON_LABEL_H: f32 = 12.0;
+const BUTTON_SIDE_MARGIN: f32 = 14.0;
 
 #[derive(Debug)]
 pub struct TitleScreen {
@@ -15,6 +16,7 @@ pub struct TitleScreen {
     focused_button: ButtonAction,
     pressed_button: Option<ButtonAction>,
     focus_visible: bool,
+    keyboard_focus_engaged: bool,
 }
 
 impl Default for TitleScreen {
@@ -24,6 +26,7 @@ impl Default for TitleScreen {
             focused_button: ButtonAction::Play,
             pressed_button: None,
             focus_visible: true,
+            keyboard_focus_engaged: false,
         }
     }
 }
@@ -68,6 +71,7 @@ impl TitleScreen {
     ) -> Option<TitleAction> {
         if input.help_pressed() {
             self.focus_visible = true;
+            self.keyboard_focus_engaged = true;
             self.pressed_button = None;
             self.toggle_menu();
             return None;
@@ -76,6 +80,7 @@ impl TitleScreen {
         let pointer_pressed = input.pointer_pressed();
         if let Some(point) = pointer_pressed {
             self.focus_visible = false;
+            self.keyboard_focus_engaged = false;
             self.pressed_button = self.button_at(
                 point,
                 params,
@@ -88,6 +93,7 @@ impl TitleScreen {
 
         if let Some(point) = input.pointer_released() {
             self.focus_visible = false;
+            self.keyboard_focus_engaged = false;
             let pressed_button = self.pressed_button.take();
             let released_button = self.button_at(
                 point,
@@ -114,6 +120,7 @@ impl TitleScreen {
 
         if input.menu_cancel_pressed() && self.instructions_open {
             self.focus_visible = true;
+            self.keyboard_focus_engaged = true;
             self.close_menu();
             return None;
         }
@@ -124,6 +131,7 @@ impl TitleScreen {
 
         if input.menu_confirm_pressed() {
             self.focus_visible = true;
+            self.keyboard_focus_engaged = true;
             return self.activate_button(self.focused_button);
         }
 
@@ -162,9 +170,10 @@ impl TitleScreen {
         let text_color = [0.82, 0.86, 0.82, 1.0];
         let accent_color = [0.9, 0.72, 0.48, 1.0];
         let buttons = self.buttons(ctx.params, ctx.text, ctx.flags.music_playing);
+        let focus_visible = self.render_focus_visible(ctx.flags.using_touch);
         let rects: Vec<(UiRect, RectStyle)> = buttons
             .iter()
-            .map(|button| (button.rect, self.button_style(button.action)))
+            .map(|button| (button.rect, self.button_style(button.action, focus_visible)))
             .collect();
         ctx.ui
             .draw_rects(ctx.device, ctx.encoder, ctx.title_ui_view, &rects);
@@ -175,7 +184,7 @@ impl TitleScreen {
             let label_x =
                 button.rect.x + (button.rect.w - ctx.text.text_width(button.label, scale)) / 2.0;
             let label_y = button.rect.y + (button.rect.h - BUTTON_LABEL_H) / 2.0;
-            let color = if self.button_highlighted(button.action) {
+            let color = if self.button_highlighted(button.action, focus_visible) {
                 accent_color
             } else {
                 button_color
@@ -217,39 +226,43 @@ impl TitleScreen {
         text: &TextRenderer,
         music_playing: bool,
     ) -> Vec<UiButton<ButtonAction>> {
-        let y = params.viewport_height as f32 - BUTTON_H - BUTTON_BOTTOM_MARGIN;
         if self.instructions_open {
             let music_label = if music_playing {
                 "MUSIC ON"
             } else {
                 "MUSIC OFF"
             };
-            let music_w = (text.text_width(music_label, 1.0) + 22.0).max(112.0);
+            let (music_w, button_h) = Self::button_size(music_label, text);
+            let (close_w, _) = Self::button_size("X", text);
+            let y = params.viewport_height as f32 - button_h - BUTTON_BOTTOM_MARGIN;
             return vec![
                 UiButton {
                     action: ButtonAction::Music,
                     label: music_label,
                     rect: UiRect {
-                        x: 18.0,
+                        x: BUTTON_SIDE_MARGIN,
                         y,
                         w: music_w,
-                        h: BUTTON_H,
+                        h: button_h,
                     },
                 },
                 UiButton {
                     action: ButtonAction::Menu,
                     label: "X",
                     rect: UiRect {
-                        x: params.viewport_width as f32 - 44.0 - BUTTON_BOTTOM_MARGIN,
+                        x: params.viewport_width as f32 - close_w - BUTTON_SIDE_MARGIN,
                         y,
-                        w: 44.0,
-                        h: BUTTON_H,
+                        w: close_w,
+                        h: button_h,
                     },
                 },
             ];
         }
 
-        let row_w = BUTTON_W * 2.0 + BUTTON_GAP;
+        let (play_w, button_h) = Self::button_size("PLAY", text);
+        let (menu_w, _) = Self::button_size("MENU", text);
+        let y = params.viewport_height as f32 - button_h - BUTTON_BOTTOM_MARGIN;
+        let row_w = play_w + menu_w + BUTTON_GAP;
         let start_x = (params.viewport_width as f32 - row_w) / 2.0;
         vec![
             UiButton {
@@ -258,18 +271,18 @@ impl TitleScreen {
                 rect: UiRect {
                     x: start_x,
                     y,
-                    w: BUTTON_W,
-                    h: BUTTON_H,
+                    w: play_w,
+                    h: button_h,
                 },
             },
             UiButton {
                 action: ButtonAction::Menu,
                 label: "MENU",
                 rect: UiRect {
-                    x: start_x + BUTTON_W + BUTTON_GAP,
+                    x: start_x + play_w + BUTTON_GAP,
                     y,
-                    w: BUTTON_W,
-                    h: BUTTON_H,
+                    w: menu_w,
+                    h: button_h,
                 },
             },
         ]
@@ -363,15 +376,16 @@ impl TitleScreen {
         } else {
             (current + 1) % buttons.len()
         };
+        self.keyboard_focus_engaged = true;
         self.focus_visible = true;
         self.pressed_button = None;
         self.focused_button = buttons[next].action;
         true
     }
 
-    fn button_style(&self, action: ButtonAction) -> RectStyle {
+    fn button_style(&self, action: ButtonAction, focus_visible: bool) -> RectStyle {
         let pressed = self.pressed_button == Some(action);
-        let focused = self.focus_visible && action == self.focused_button;
+        let focused = focus_visible && action == self.focused_button;
         RectStyle {
             fill_color: if pressed {
                 [0.12, 0.16, 0.16, 0.9]
@@ -389,7 +403,17 @@ impl TitleScreen {
         }
     }
 
-    fn button_highlighted(&self, action: ButtonAction) -> bool {
-        self.pressed_button == Some(action) || (self.focus_visible && action == self.focused_button)
+    fn button_highlighted(&self, action: ButtonAction, focus_visible: bool) -> bool {
+        self.pressed_button == Some(action) || (focus_visible && action == self.focused_button)
+    }
+
+    fn render_focus_visible(&self, using_touch: bool) -> bool {
+        self.focus_visible && (self.keyboard_focus_engaged || !using_touch)
+    }
+
+    fn button_size(label: &str, text: &TextRenderer) -> (f32, f32) {
+        let w = (text.text_width(label, 1.0) + BUTTON_PAD_X * 2.0).round();
+        let h = (BUTTON_LABEL_H + BUTTON_PAD_Y * 2.0).round();
+        (w, h)
     }
 }

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -206,8 +206,8 @@ impl TitleScreen {
                 vec![
                     ("OBJECTIVE", 24.0, accent_color),
                     ("BLAST AND CLIMB", 42.0, text_color),
-                    ("W -> GAS", 64.0, text_color),
-                    ("A/D -> STEER", 82.0, text_color),
+                    ("W/UP -> GAS", 64.0, text_color),
+                    ("A/D/ARROWS -> STEER", 82.0, text_color),
                 ]
             };
             texts.extend(lines.into_iter().map(|(line, y, color)| {

--- a/src/screens/title.rs
+++ b/src/screens/title.rs
@@ -1,10 +1,27 @@
 use spout::game_params::GameParams;
 use spout::input::{InputFrame, PointerPress};
 use spout::text::TextRenderer;
+use spout::ui::{self, RectStyle, UiButton, UiRect, UiRenderer};
 
-#[derive(Debug, Default)]
+const BUTTON_W: f32 = 78.0;
+const BUTTON_H: f32 = 34.0;
+const BUTTON_GAP: f32 = 12.0;
+const BUTTON_BOTTOM_MARGIN: f32 = 14.0;
+const BUTTON_LABEL_H: f32 = 12.0;
+
+#[derive(Debug)]
 pub struct TitleScreen {
     instructions_open: bool,
+    focused_button: ButtonAction,
+}
+
+impl Default for TitleScreen {
+    fn default() -> Self {
+        Self {
+            instructions_open: false,
+            focused_button: ButtonAction::Play,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -19,30 +36,21 @@ pub struct TitleRenderFlags {
     pub using_touch: bool,
 }
 
+pub struct TitleUiRenderContext<'a> {
+    pub device: &'a wgpu::Device,
+    pub encoder: &'a mut wgpu::CommandEncoder,
+    pub title_ui_view: &'a wgpu::TextureView,
+    pub ui: &'a UiRenderer,
+    pub params: &'a GameParams,
+    pub text: &'a TextRenderer,
+    pub flags: TitleRenderFlags,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ButtonAction {
+    Play,
+    Menu,
     Music,
-    Help,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct UiRect {
-    x: f32,
-    y: f32,
-    w: f32,
-    h: f32,
-}
-
-impl UiRect {
-    fn contains(&self, x: f32, y: f32) -> bool {
-        x >= self.x && x <= self.x + self.w && y >= self.y && y <= self.y + self.h
-    }
-}
-
-struct Button {
-    action: ButtonAction,
-    label: &'static str,
-    rect: UiRect,
 }
 
 impl TitleScreen {
@@ -64,79 +72,44 @@ impl TitleScreen {
                 surface_size.1,
             )
         });
-        let mut title_action_handled = false;
 
         if input.help_pressed() {
-            self.instructions_open = !self.instructions_open;
-            title_action_handled = true;
+            self.toggle_menu();
+            return None;
         }
 
         if let Some(action) = clicked_button {
-            match action {
-                ButtonAction::Music => {
-                    return Some(TitleAction::ToggleMusic);
-                }
-                ButtonAction::Help => {
-                    self.instructions_open = !self.instructions_open;
-                }
-            }
-            title_action_handled = true;
+            self.focused_button = action;
+            return self.activate_button(action);
         } else if self.instructions_open && input.pointer_pressed().is_some() {
-            self.instructions_open = false;
-            title_action_handled = true;
+            self.close_menu();
+            return None;
         }
 
-        if !title_action_handled
-            && !self.instructions_open
-            && (input.thrust_started() || input.rotate_started())
-        {
+        let buttons = self.buttons(params, text, music_playing);
+        self.ensure_focus_visible(&buttons);
+
+        if input.menu_cancel_pressed() && self.instructions_open {
+            self.close_menu();
+            return None;
+        }
+
+        if self.move_focus_from_input(input, &buttons) {
+            return None;
+        }
+
+        if input.menu_confirm_pressed() {
+            return self.activate_button(self.focused_button);
+        }
+
+        if !self.instructions_open && (input.thrust_started() || input.rotate_started()) {
             return Some(TitleAction::StartGame);
         }
 
         None
     }
 
-    pub fn draw_help_button(
-        &self,
-        device: &wgpu::Device,
-        encoder: &mut wgpu::CommandEncoder,
-        game_view_texture: &wgpu::TextureView,
-        params: &GameParams,
-        text: &TextRenderer,
-    ) {
-        if self.instructions_open {
-            return;
-        }
-
-        let Some(button) = self
-            .buttons(params, text, false)
-            .into_iter()
-            .find(|button| button.action == ButtonAction::Help)
-        else {
-            return;
-        };
-
-        let color = [0.55, 0.55, 0.55, 1.0];
-        let label_x = button.rect.x + (button.rect.w - text.text_width(button.label, 1.0)) / 2.0;
-        let label_y = button.rect.y + (button.rect.h - 12.0) / 2.0;
-
-        text.draw(
-            device,
-            encoder,
-            game_view_texture,
-            &[(button.label, label_x, label_y, 1.0, color)],
-        );
-    }
-
-    pub fn prepare_ui(
-        &self,
-        device: &wgpu::Device,
-        encoder: &mut wgpu::CommandEncoder,
-        title_ui_view: &wgpu::TextureView,
-        params: &GameParams,
-        text: &TextRenderer,
-        flags: TitleRenderFlags,
-    ) {
+    pub fn prepare_ui(&self, ctx: TitleUiRenderContext<'_>) {
         let clear_color = if self.instructions_open {
             wgpu::Color {
                 r: 0.02,
@@ -148,10 +121,10 @@ impl TitleScreen {
             wgpu::Color::TRANSPARENT
         };
         {
-            let _pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            let _pass = ctx.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("title_ui_clear"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: title_ui_view,
+                    view: ctx.title_ui_view,
                     resolve_target: None,
                     depth_slice: None,
                     ops: wgpu::Operations {
@@ -167,24 +140,32 @@ impl TitleScreen {
         let button_color = [0.7, 0.78, 0.78, 1.0];
         let text_color = [0.82, 0.86, 0.82, 1.0];
         let accent_color = [0.9, 0.72, 0.48, 1.0];
-        let buttons = self.buttons(params, text, flags.music_playing);
+        let buttons = self.buttons(ctx.params, ctx.text, ctx.flags.music_playing);
+        let rects: Vec<(UiRect, RectStyle)> = buttons
+            .iter()
+            .map(|button| (button.rect, self.button_style(button.action)))
+            .collect();
+        ctx.ui
+            .draw_rects(ctx.device, ctx.encoder, ctx.title_ui_view, &rects);
 
         let mut texts: Vec<(&str, f32, f32, f32, [f32; 4])> = Vec::new();
-        for button in buttons
-            .iter()
-            .filter(|button| button.action != ButtonAction::Help || self.instructions_open)
-        {
+        for button in &buttons {
             let scale = 1.0;
             let label_x =
-                button.rect.x + (button.rect.w - text.text_width(button.label, scale)) / 2.0;
-            let label_y = button.rect.y + (button.rect.h - 12.0) / 2.0;
-            texts.push((button.label, label_x, label_y, scale, button_color));
+                button.rect.x + (button.rect.w - ctx.text.text_width(button.label, scale)) / 2.0;
+            let label_y = button.rect.y + (button.rect.h - BUTTON_LABEL_H) / 2.0;
+            let color = if button.action == self.focused_button {
+                accent_color
+            } else {
+                button_color
+            };
+            texts.push((button.label, label_x, label_y, scale, color));
         }
 
         if self.instructions_open {
-            let w = text.surface_width;
+            let w = ctx.text.surface_width;
             let scale = 1.0;
-            let lines: Vec<(&str, f32, [f32; 4])> = if flags.using_touch {
+            let lines: Vec<(&str, f32, [f32; 4])> = if ctx.flags.using_touch {
                 vec![
                     ("OBJECTIVE", 24.0, accent_color),
                     ("BLAST AND CLIMB", 42.0, text_color),
@@ -200,12 +181,13 @@ impl TitleScreen {
                 ]
             };
             texts.extend(lines.into_iter().map(|(line, y, color)| {
-                let x = (w - text.text_width(line, scale)) / 2.0;
+                let x = (w - ctx.text.text_width(line, scale)) / 2.0;
                 (line, x, y, scale, color)
             }));
         }
 
-        text.draw(device, encoder, title_ui_view, &texts);
+        ctx.text
+            .draw(ctx.device, ctx.encoder, ctx.title_ui_view, &texts);
     }
 
     fn buttons(
@@ -213,42 +195,63 @@ impl TitleScreen {
         params: &GameParams,
         text: &TextRenderer,
         music_playing: bool,
-    ) -> Vec<Button> {
-        let pad_x = 4.0;
-        let button_h = 32.0;
-        let help_y = params.viewport_height as f32 - button_h - 6.0;
-        let help_label = if self.instructions_open { "X" } else { "?" };
-        let mut buttons = vec![Button {
-            action: ButtonAction::Help,
-            label: help_label,
-            rect: UiRect {
-                x: params.viewport_width as f32 - 56.0 - 6.0,
-                y: help_y,
-                w: 56.0,
-                h: button_h,
-            },
-        }];
-
+    ) -> Vec<UiButton<ButtonAction>> {
+        let y = params.viewport_height as f32 - BUTTON_H - BUTTON_BOTTOM_MARGIN;
         if self.instructions_open {
             let music_label = if music_playing {
-                "[MUSIC ON]"
+                "MUSIC ON"
             } else {
-                "[MUSIC OFF]"
+                "MUSIC OFF"
             };
-            let music_w = text.text_width(music_label, 1.0) + pad_x * 2.0;
-            buttons.push(Button {
-                action: ButtonAction::Music,
-                label: music_label,
-                rect: UiRect {
-                    x: 18.0,
-                    y: 100.0,
-                    w: music_w,
-                    h: button_h,
+            let music_w = (text.text_width(music_label, 1.0) + 18.0).max(96.0);
+            return vec![
+                UiButton {
+                    action: ButtonAction::Music,
+                    label: music_label,
+                    rect: UiRect {
+                        x: 18.0,
+                        y,
+                        w: music_w,
+                        h: BUTTON_H,
+                    },
                 },
-            });
+                UiButton {
+                    action: ButtonAction::Menu,
+                    label: "X",
+                    rect: UiRect {
+                        x: params.viewport_width as f32 - 44.0 - BUTTON_BOTTOM_MARGIN,
+                        y,
+                        w: 44.0,
+                        h: BUTTON_H,
+                    },
+                },
+            ];
         }
 
-        buttons
+        let row_w = BUTTON_W * 2.0 + BUTTON_GAP;
+        let start_x = (params.viewport_width as f32 - row_w) / 2.0;
+        vec![
+            UiButton {
+                action: ButtonAction::Play,
+                label: "PLAY",
+                rect: UiRect {
+                    x: start_x,
+                    y,
+                    w: BUTTON_W,
+                    h: BUTTON_H,
+                },
+            },
+            UiButton {
+                action: ButtonAction::Menu,
+                label: "MENU",
+                rect: UiRect {
+                    x: start_x + BUTTON_W + BUTTON_GAP,
+                    y,
+                    w: BUTTON_W,
+                    h: BUTTON_H,
+                },
+            },
+        ]
     }
 
     fn button_at(
@@ -260,56 +263,101 @@ impl TitleScreen {
         surface_width: u32,
         surface_height: u32,
     ) -> Option<ButtonAction> {
-        if title_help_surface_hit(point, surface_width, surface_height) {
-            return Some(ButtonAction::Help);
-        }
-
-        let (game_x, game_y) = surface_to_game_point(point, params, surface_width, surface_height)?;
+        let (game_x, game_y) = ui::surface_to_game_point(
+            point,
+            params.viewport_width,
+            params.viewport_height,
+            surface_width,
+            surface_height,
+        )?;
         self.buttons(params, text, music_playing)
             .iter()
             .find(|button| button.rect.contains(game_x, game_y))
             .map(|button| button.action)
     }
-}
 
-fn surface_to_game_point(
-    point: PointerPress,
-    params: &GameParams,
-    surface_width: u32,
-    surface_height: u32,
-) -> Option<(f32, f32)> {
-    if surface_width == 0 || surface_height == 0 {
-        return None;
+    fn activate_button(&mut self, action: ButtonAction) -> Option<TitleAction> {
+        match action {
+            ButtonAction::Play => Some(TitleAction::StartGame),
+            ButtonAction::Menu => {
+                self.toggle_menu();
+                None
+            }
+            ButtonAction::Music => Some(TitleAction::ToggleMusic),
+        }
     }
 
-    let game_w = params.viewport_width as f32;
-    let game_h = params.viewport_height as f32;
-    let surface_w = surface_width as f32;
-    let surface_h = surface_height as f32;
-    let scale = (surface_w / game_w)
-        .min(surface_h / game_h)
-        .floor()
-        .max(1.0);
-    let draw_w = game_w * scale;
-    let draw_h = game_h * scale;
-    let offset_x = ((surface_w - draw_w) * 0.5).floor();
-    let offset_y = ((surface_h - draw_h) * 0.5).floor();
-
-    if point.x < offset_x
-        || point.x > offset_x + draw_w
-        || point.y < offset_y
-        || point.y > offset_y + draw_h
-    {
-        return None;
+    fn toggle_menu(&mut self) {
+        if self.instructions_open {
+            self.close_menu();
+        } else {
+            self.instructions_open = true;
+            self.focused_button = ButtonAction::Menu;
+        }
     }
 
-    let game_x = (point.x - offset_x) / draw_w * game_w;
-    let game_y = (point.y - offset_y) / draw_h * game_h;
-    Some((game_x, game_y))
-}
+    fn close_menu(&mut self) {
+        self.instructions_open = false;
+        self.focused_button = ButtonAction::Menu;
+    }
 
-fn title_help_surface_hit(point: PointerPress, surface_width: u32, surface_height: u32) -> bool {
-    let w = surface_width as f32;
-    let h = surface_height as f32;
-    point.x >= w * 0.72 && point.y >= h * 0.62
+    fn ensure_focus_visible(&mut self, buttons: &[UiButton<ButtonAction>]) {
+        if buttons
+            .iter()
+            .any(|button| button.action == self.focused_button)
+        {
+            return;
+        }
+
+        if let Some(button) = buttons.first() {
+            self.focused_button = button.action;
+        }
+    }
+
+    fn move_focus_from_input(
+        &mut self,
+        input: InputFrame,
+        buttons: &[UiButton<ButtonAction>],
+    ) -> bool {
+        let delta = if input.menu_left_pressed() || input.menu_up_pressed() {
+            -1
+        } else if input.menu_right_pressed() || input.menu_down_pressed() {
+            1
+        } else {
+            0
+        };
+
+        if delta == 0 || buttons.is_empty() {
+            return false;
+        }
+
+        let current = buttons
+            .iter()
+            .position(|button| button.action == self.focused_button)
+            .unwrap_or(0);
+        let next = if delta < 0 {
+            current.checked_sub(1).unwrap_or(buttons.len() - 1)
+        } else {
+            (current + 1) % buttons.len()
+        };
+        self.focused_button = buttons[next].action;
+        true
+    }
+
+    fn button_style(&self, action: ButtonAction) -> RectStyle {
+        let focused = action == self.focused_button;
+        RectStyle {
+            fill_color: if focused {
+                [0.08, 0.12, 0.13, 0.78]
+            } else {
+                [0.02, 0.05, 0.07, 0.68]
+            },
+            outline_color: if focused {
+                [0.9, 0.72, 0.48, 1.0]
+            } else {
+                [0.45, 0.57, 0.58, 0.92]
+            },
+            outline_px: if focused { 2.0 } else { 1.0 },
+        }
+    }
 }

--- a/src/shaders/ui_rect.wgsl
+++ b/src/shaders/ui_rect.wgsl
@@ -1,0 +1,68 @@
+// Low-resolution UI rectangle renderer.
+//
+// Draws instanced filled rectangles with a pixel outline into a game-sized
+// render target. Coordinates match TextRenderer's y_dir convention.
+
+struct ScreenUniform {
+    size: vec2<f32>,
+    y_dir: f32,
+    _pad: f32,
+};
+
+@group(0) @binding(0) var<uniform> screen: ScreenUniform;
+
+struct VertexInput {
+    @builtin(vertex_index) vertex_index: u32,
+    @location(0) pos: vec2<f32>,
+    @location(1) size: vec2<f32>,
+    @location(2) fill_color: vec4<f32>,
+    @location(3) outline_color: vec4<f32>,
+    @location(4) outline_px: f32,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) local_pos: vec2<f32>,
+    @location(1) size: vec2<f32>,
+    @location(2) fill_color: vec4<f32>,
+    @location(3) outline_color: vec4<f32>,
+    @location(4) outline_px: f32,
+};
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    let u_idx = input.vertex_index & 1u;
+    let v_idx = input.vertex_index >> 1u;
+    let local_pos = vec2<f32>(
+        f32(u_idx) * input.size.x,
+        f32(v_idx) * input.size.y,
+    );
+    let pixel_pos = input.pos + local_pos;
+
+    let ndc_x = pixel_pos.x / screen.size.x * 2.0 - 1.0;
+    let ndc_y = screen.y_dir * (1.0 - pixel_pos.y / screen.size.y * 2.0);
+
+    var out: VertexOutput;
+    out.position = vec4<f32>(ndc_x, ndc_y, 0.0, 1.0);
+    out.local_pos = local_pos;
+    out.size = input.size;
+    out.fill_color = input.fill_color;
+    out.outline_color = input.outline_color;
+    out.outline_px = input.outline_px;
+    return out;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    let border = input.outline_px > 0.0 && (
+        input.local_pos.x < input.outline_px ||
+        input.local_pos.y < input.outline_px ||
+        input.local_pos.x >= input.size.x - input.outline_px ||
+        input.local_pos.y >= input.size.y - input.outline_px
+    );
+
+    if border {
+        return input.outline_color;
+    }
+    return input.fill_color;
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,330 @@
+//! Tiny game-space UI primitives for menu screens.
+//!
+//! This is deliberately smaller than a GUI framework: screens own their state
+//! and actions, while this module provides shared rect math, buttons, and a
+//! low-resolution rectangle renderer.
+
+use wgpu::util::DeviceExt;
+
+use crate::input::PointerPress;
+use crate::text::YDirection;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct UiRect {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
+impl UiRect {
+    pub fn contains(&self, x: f32, y: f32) -> bool {
+        x >= self.x && x <= self.x + self.w && y >= self.y && y <= self.y + self.h
+    }
+
+    pub fn centered(width: f32, height: f32, center_x: f32, center_y: f32) -> Self {
+        Self {
+            x: center_x - width / 2.0,
+            y: center_y - height / 2.0,
+            w: width,
+            h: height,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UiButton<A> {
+    pub action: A,
+    pub label: &'static str,
+    pub rect: UiRect,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RectStyle {
+    pub fill_color: [f32; 4],
+    pub outline_color: [f32; 4],
+    pub outline_px: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct ScreenUniform {
+    size: [f32; 2],
+    y_dir: f32,
+    _pad: f32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct RectInstance {
+    pos: [f32; 2],
+    size: [f32; 2],
+    fill_color: [f32; 4],
+    outline_color: [f32; 4],
+    outline_px: f32,
+    _pad: [f32; 3],
+}
+
+pub struct UiRenderer {
+    pipeline: wgpu::RenderPipeline,
+    _screen_uniform_buf: wgpu::Buffer,
+    screen_bind_group: wgpu::BindGroup,
+}
+
+impl UiRenderer {
+    pub fn new(
+        device: &wgpu::Device,
+        target_format: wgpu::TextureFormat,
+        surface_width: u32,
+        surface_height: u32,
+        y_direction: YDirection,
+    ) -> Self {
+        let y_dir = match y_direction {
+            YDirection::Down => 1.0,
+            YDirection::Up => -1.0,
+        };
+        let screen_uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("UI Rect Screen Uniform"),
+            contents: bytemuck::bytes_of(&ScreenUniform {
+                size: [surface_width as f32, surface_height as f32],
+                y_dir,
+                _pad: 0.0,
+            }),
+            usage: wgpu::BufferUsages::UNIFORM,
+        });
+
+        let screen_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("UI Rect Screen BGL"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(
+                        std::mem::size_of::<ScreenUniform>() as u64
+                    ),
+                },
+                count: None,
+            }],
+        });
+
+        let screen_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("UI Rect Screen BG"),
+            layout: &screen_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: screen_uniform_buf.as_entire_binding(),
+            }],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("UI Rect Shader"),
+            source: wgpu::ShaderSource::Wgsl(crate::include_shader!("ui_rect.wgsl")),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("UI Rect Pipeline Layout"),
+            bind_group_layouts: &[Some(&screen_bgl)],
+            immediate_size: 0,
+        });
+
+        let vertex_size = std::mem::size_of::<RectInstance>() as wgpu::BufferAddress;
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("UI Rect Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: vertex_size,
+                    step_mode: wgpu::VertexStepMode::Instance,
+                    attributes: &[
+                        wgpu::VertexAttribute {
+                            offset: 0,
+                            shader_location: 0,
+                            format: wgpu::VertexFormat::Float32x2,
+                        },
+                        wgpu::VertexAttribute {
+                            offset: 8,
+                            shader_location: 1,
+                            format: wgpu::VertexFormat::Float32x2,
+                        },
+                        wgpu::VertexAttribute {
+                            offset: 16,
+                            shader_location: 2,
+                            format: wgpu::VertexFormat::Float32x4,
+                        },
+                        wgpu::VertexAttribute {
+                            offset: 32,
+                            shader_location: 3,
+                            format: wgpu::VertexFormat::Float32x4,
+                        },
+                        wgpu::VertexAttribute {
+                            offset: 48,
+                            shader_location: 4,
+                            format: wgpu::VertexFormat::Float32,
+                        },
+                    ],
+                }],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: target_format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            cache: None,
+            multiview_mask: None,
+        });
+
+        Self {
+            pipeline,
+            _screen_uniform_buf: screen_uniform_buf,
+            screen_bind_group,
+        }
+    }
+
+    pub fn draw_rects(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        rects: &[(UiRect, RectStyle)],
+    ) {
+        if rects.is_empty() {
+            return;
+        }
+
+        let instances: Vec<RectInstance> = rects
+            .iter()
+            .map(|(rect, style)| RectInstance {
+                pos: [rect.x.round(), rect.y.round()],
+                size: [rect.w.round().max(1.0), rect.h.round().max(1.0)],
+                fill_color: style.fill_color,
+                outline_color: style.outline_color,
+                outline_px: style.outline_px.round().max(0.0),
+                _pad: [0.0; 3],
+            })
+            .collect();
+        let instance_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("UI Rect Instances"),
+            contents: bytemuck::cast_slice(&instances),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("UI Rect Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            ..Default::default()
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &self.screen_bind_group, &[]);
+        pass.set_vertex_buffer(0, instance_buf.slice(..));
+        pass.draw(0..4, 0..instances.len() as u32);
+    }
+}
+
+pub fn surface_to_game_point(
+    point: PointerPress,
+    viewport_width: u32,
+    viewport_height: u32,
+    surface_width: u32,
+    surface_height: u32,
+) -> Option<(f32, f32)> {
+    if surface_width == 0 || surface_height == 0 {
+        return None;
+    }
+
+    let game_w = viewport_width as f32;
+    let game_h = viewport_height as f32;
+    let surface_w = surface_width as f32;
+    let surface_h = surface_height as f32;
+    let scale = (surface_w / game_w)
+        .min(surface_h / game_h)
+        .floor()
+        .max(1.0);
+    let draw_w = game_w * scale;
+    let draw_h = game_h * scale;
+    let offset_x = ((surface_w - draw_w) * 0.5).floor();
+    let offset_y = ((surface_h - draw_h) * 0.5).floor();
+
+    if point.x < offset_x
+        || point.x > offset_x + draw_w
+        || point.y < offset_y
+        || point.y > offset_y + draw_h
+    {
+        return None;
+    }
+
+    let game_x = (point.x - offset_x) / draw_w * game_w;
+    let game_y = (point.y - offset_y) / draw_h * game_h;
+    Some((game_x, game_y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rect_contains_edges() {
+        let rect = UiRect {
+            x: 10.0,
+            y: 20.0,
+            w: 30.0,
+            h: 40.0,
+        };
+
+        assert!(rect.contains(10.0, 20.0));
+        assert!(rect.contains(40.0, 60.0));
+        assert!(!rect.contains(9.9, 20.0));
+        assert!(!rect.contains(40.1, 60.0));
+    }
+
+    #[test]
+    fn maps_letterboxed_surface_point_to_game_space() {
+        let point = PointerPress { x: 200.0, y: 100.0 };
+        let mapped = surface_to_game_point(point, 100, 50, 400, 300).expect("inside game area");
+
+        assert_eq!(mapped, (50.0, 12.5));
+        assert!(
+            surface_to_game_point(PointerPress { x: 200.0, y: 20.0 }, 100, 50, 400, 300).is_none()
+        );
+    }
+
+    #[test]
+    fn ui_rect_renderer_constructs_headless() {
+        let Some((device, _queue)) = crate::gpu_test_utils::try_create_headless_device() else {
+            eprintln!("No headless GPU adapter available; skipping ui_rect_renderer_constructs");
+            return;
+        };
+
+        let _renderer = UiRenderer::new(
+            &device,
+            crate::bloom::GAME_VIEW_FORMAT,
+            64,
+            32,
+            YDirection::Up,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- replace the title-screen ? affordance with boxed PLAY and MENU buttons
- add semantic menu input edges for arrow navigation, Enter/Space confirm, and Escape cancel
- add a small shared UI rect/button layer plus a low-res rectangle renderer for crisp button boxes
- update title-screen plan notes

## Behavior
- PLAY starts the game
- MENU opens the existing help overlay
- while the help overlay is open, X closes it and MUSIC ON/OFF remains available
- arrow keys move focus between visible title buttons; Enter/Space activates the focused button

## Testing
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test --verbose