### PR TITLE
Add architecture guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,8 @@ RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build --target wasm32-unknown-unknow
 
 | Path | Purpose |
 |------|---------|
-| `src/main.rs` | Entry point, game loop, winit event handling, state machine |
+| `src/app.rs` | winit app harness, window/surface lifecycle, platform event handling |
+| `src/main.rs` | Game loop, state machine, simulation/render phase coordination |
 | `src/particles.rs` | Particle system: GPU buffers, emitters, compute pass |
 | `src/level_manager.rs` | Level/terrain generation and progressive scrolling |
 | `src/render.rs` | Top-level render pipeline coordination |
@@ -35,13 +36,11 @@ RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build --target wasm32-unknown-unknow
 | `src/camera.rs` | Camera/viewport transforms |
 | `src/game_params.rs` | Config structs (deserialized from `game_config.toml`) |
 | `src/shaders/` | WGSL compute and render shaders |
-| `examples/framework.rs` | winit app harness (shared by main and tests) |
-| `int_grid/` | Local sub-crate: fixed-point 2D integer grid |
 | `build.rs` | Generates shaders at compile time via `tera` templating |
 
 ## Shaders
 
-Shaders are in `src/shaders/` as WGSL. `build.rs` uses `tera` to inject constants from `int_grid` at compile time. Do not edit generated shader output directly — edit the `.wgsl` or `.wgsl.include` source files.
+Shaders are in `src/shaders/` as WGSL. `build.rs` uses `tera` to inject compile-time constants such as compute workgroup size. Do not edit generated shader output directly — edit the `.wgsl` or `.wgsl.include` source files.
 
 After any GPU or WASM change, read `_context/wasm-debugging.md` for known pitfalls before committing.
 

--- a/_context/plans/active/architecture-cleanup.md
+++ b/_context/plans/active/architecture-cleanup.md
@@ -1,0 +1,160 @@
+# Architecture Cleanup
+
+Active follow-up from the May 2026 architecture review. Apply the principle of
+progressively revealing complexity: top-level files should name game phases and
+screen flow, while detailed GPU/platform/UI mechanics live behind narrower
+modules.
+
+## Recently Completed
+
+Merged in PRs #77-#84:
+- [x] Replaced boolean game-state flags with an explicit `AppState` enum and
+      `Play` state.
+- [x] Split the frame loop into `update_phase`, GPU-bound transitions,
+      `draw_phase`, and `post_phase`.
+- [x] Extracted title-screen behavior into `src/screens/title.rs`.
+- [x] Added `InputFrame` edge helpers and routed audio hotkeys through input.
+- [x] Grouped render resources into `src/graphics.rs`.
+- [x] Replaced the title `?` affordance with `PLAY` / `MENU` buttons and exact
+      game-space hit testing.
+- [x] Fixed collision readback while paused so in-flight readbacks do not block
+      later dispatch after unpausing.
+- [x] Added `GameParams::validate()`, fail-fast embedded config parsing,
+      unknown-field rejection, and semantic range tests for config knobs.
+- [x] Guarded the current width invariant by validating
+      `level_width == viewport_width` until terrain/view/density widths split.
+- [x] Renamed the CPU `Particle` ABI field to `subframe_dt_offset`, made it
+      a one-frame dt offset with `0.0` as the neutral value.
+
+## Highest Priority
+
+- [ ] Fix density-buffer clear dispatch bounds. `clear_density_buffer.wgsl`
+      writes `density_buffer[gid]` without guarding rounded-up workgroup lanes;
+      the checked-in 261×160 viewport dispatches 41,984 lanes for 41,760 cells.
+      Add an `arrayLength` guard and cover a non-workgroup-multiple density
+      size.
+- [x] Add config validation and fail-fast checked-in config parsing. Today the
+      loader can fall through to `GameParams::default()` after a broken embedded
+      `game_config.toml`, and tests can still pass. Add `GameParams::validate()`,
+      run it after every parse path, and test `include_str!("../game_config.toml")`
+      directly.
+- [x] Guard width invariants before wider-level work. Particle and terrain
+      shaders still conflate view width, terrain row stride, and density-buffer
+      width: `ParticleSystem::new` writes `level_width` into the shader
+      `viewport_width` uniform while the density buffer is allocated with
+      `viewport_width`, and `TerrainRenderer` has the same naming confusion.
+      Validate `level_width == viewport_width` for now, then split terrain
+      width, view width, and density-view width before enabling wider levels.
+- [x] Fix the CPU/GPU particle ABI: Rust called the fourth `Particle` field
+      `_padding`, but WGSL treats it as `subframe_dt_offset`. Rename it to
+      `subframe_dt_offset`, make it a one-frame dt offset with `0.0` as the
+      neutral value, and keep the Rust/WGSL layout explicitly aligned.
+- [ ] Revisit collision scheduling beyond pause handling. The current
+      `PendingCollisionSegment` still extends one segment to the latest ship
+      pose while readback is in flight; curved/dogleg motion can collapse into
+      one chord. The native readback lifecycle can occupy the in-flight slot
+      across extra frame motion. Introduce a `CollisionTracker` with queued
+      per-frame motion segments or a small ring of readback buffers.
+
+## Gameplay / Simulation
+
+- [ ] Make terrain mutation order a named GPU-frame contract. The current draw
+      frame composes terrain, runs particle erosion, then dispatches ship
+      collision against the mutated terrain. Keep that if desired, but encode it
+      explicitly as `collide_after_erosion` or change the order deliberately.
+- [ ] Make terrain erosion saturating. `try_erode` subtracts damage before
+      checking solidity, so empty cells can become negative terrain. Clamp empty
+      terrain at zero before adding richer material or damage semantics.
+- [ ] Centralize ship geometry shared by Rust and WGSL so render, collision,
+      and emitter offsets cannot drift again.
+- [ ] Rename or hide CPU terrain query helpers that read initial pre-erosion
+      level data, so future AI/debug/gameplay code does not confuse them with
+      authoritative mutable terrain. This is lower urgency until production code
+      consumes those helpers.
+- [ ] Decide the terrain-authority and eviction model for tile recycling.
+      `decompose_tiles` persists GPU mutations only into loaded GPU tile
+      buffers; CPU `level_maker.levels` remains initial terrain. Recycling old
+      buffers safely needs an explicit persistence/eviction rule.
+- [ ] Add seeded level generation for reproducible runs/tests. This is useful,
+      but lower priority than tile persistence unless deterministic replay work
+      starts soon.
+- [ ] Remove or defer unreachable placeholder `AppState` variants
+      (`Settings`, `Leaderboard`) until those screens exist; today they add
+      match noise without reducing complexity.
+- [ ] Avoid startup double initialization: `Spout::init` builds gameplay level
+      and particle resources, submits them, then immediately rebuilds title
+      resources through `transition_to_title`.
+
+## Rendering / UI
+
+- [ ] Move render-target formats and texture creation out of `bloom.rs` into a
+      render-target/formats owner; bloom should consume the HDR format, not own
+      the whole game-view contract.
+- [ ] Fix and test bloom mip-level clamping. The current clamp appears to
+      undercount the legal 1×1 tail level for power-of-two texture dimensions.
+- [ ] Extract a behavior-preserving `FrameRenderer` facade after `Graphics`.
+      `Graphics` currently groups resources, but `Spout::draw_phase` still owns
+      pass order, overlays, submit/readback timing, and HUD drawing. Move the
+      frame rendering API behind a narrow facade while keeping compute/collision
+      scheduling explicit for now.
+- [ ] Batch dynamic UI instances with reusable/ring buffers. `TextRenderer` and
+      `UiRenderer` both create fresh GPU buffers per draw; use a shared dynamic
+      instance upload helper for text glyphs and UI rects.
+- [ ] Unify post-composite surface overlays or move them before final composite
+      so non-sRGB WebGPU surfaces get one consistent color-space policy.
+- [ ] Centralize game-to-surface mapping. CPU hit testing, title overlay WGSL,
+      and camera letterboxing each encode related integer-scale/letterbox math.
+      Fold this into the `SurfaceMetrics` work so rendering and input share one
+      coordinate policy.
+- [ ] Have screens emit a small UI draw model (clear color, rects, text runs,
+      overlay flags) instead of taking raw GPU rendering context. This keeps
+      future settings/leaderboard screens from opening render passes directly.
+- [ ] Fold fullscreen-pass boilerplate cleanup into the render-target/overlay
+      work; do not add a standalone abstraction unless it removes real repeated
+      pass setup.
+- [ ] Small cleanup: remove unused constructor parameters such as the discarded
+      `queue` in `TouchZoneIndicator::new`, and store decoded background tile
+      dimensions instead of hardcoding `tile_size: 65.0`.
+- [ ] Align shader ABI names and constants: split particle `view_width`,
+      `density_width`, and `terrain_stride`; make terrain uniform signedness
+      match Rust; resolve dead emitter velocity fields; and move density heat
+      scale into a shared include or build-time constant.
+
+## Platform / Boundaries
+
+- [ ] Add a `SurfaceMetrics` boundary owned by `app.rs`. Explicitly distinguish
+      surface/backing pixels, window inner/outer sizes, scale factor, game
+      viewport, and pointer coordinate mapping. Pass one metrics object through
+      input, resize, rendering, debug text, and UI hit testing.
+- [ ] Add `RuntimeCommand` / `RuntimeCapabilities`. `Spout` should request
+      runtime actions (fullscreen, cursor visibility, quit/cancel semantics)
+      and consume capabilities (touch-first UI, tap restart), while `app.rs`
+      executes window/platform policy. This should also fix the current
+      split-brain Escape handling where `app.rs` exits before `InputCollector`
+      can expose `menu_cancel`.
+- [ ] Move WASM touch attachment and native/window event adaptation out of
+      gameplay-owned `Spout` over time. Split platform adapters
+      (`WinitInputAdapter`, `DomTouchAdapter`) from pure logical input.
+- [ ] Split logical input domains: `PlayerInput`, `UiInput`, `RuntimeAction`,
+      and debug controls are currently all fields on one `InputState`.
+- [ ] Finish extracting audio decoder/executor/sink seams. `audio.rs` already
+      has a backend trait and playlist state; the remaining coupling is track
+      decoding/job execution inside native and WASM `start_track`. Keep
+      `AudioPlayer::toggle/next_track` stable so a WASM Web Worker executor can
+      land without reshaping callers.
+
+## Config / CI
+
+- [x] Add semantic `GameParams` range tests for public knobs (`color_map`,
+      density scale/exponent, particle counts/lifetimes, widths). This should
+      share the validation path from the highest-priority config task.
+- [ ] Consolidate tag release publishing: Linux and macOS workflows both trigger
+      on `v*` tags and can race to create/update the GitHub Release. Use one
+      publisher after artifacts are built, with explicit `contents: write`
+      permissions.
+- [ ] Make visual regression tests blocking with deterministic pixel/histogram
+      assertions. Prefer this over restoring fragile goldens; the project has
+      already removed unmaintainable golden files once.
+- [ ] Ensure at least one GPU availability check fails in CI if the expected
+      headless adapter is unavailable; individual GPU tests currently skip
+      themselves when no adapter is found.

--- a/_context/plans/active/longterm-features.md
+++ b/_context/plans/active/longterm-features.md
@@ -67,11 +67,13 @@ Visuals are considered high-priority — the game lives or dies on how stimulati
 ## Audio
 
 - **Procedural sound effects** — thruster pitch tied to speed/throttle
-- ✦ **WASM audio** — Web Audio playback (Phase 2 of music plan)
+- ✦ **WASM audio worker** — Web Audio playback exists; move tracker rendering
+  off the browser main thread after the audio executor/sink seam lands.
 
 ## Platform / Infrastructure
 
-- **WASM revival** — get the web target building and running again
+- **WASM hardening** — web target builds in CI; keep improving browser runtime,
+  audio unlock behavior, and visual verification.
 - ✦ **Gamepad input** — controller support via gilrs or winit gamepad events
 
 - **Configurable keybindings** — runtime remapping beyond game_config.toml

--- a/_context/plans/active/near-term.md
+++ b/_context/plans/active/near-term.md
@@ -1,15 +1,16 @@
 # Near-Term Features
 
 Concrete next things to build — one step above backlog, not yet in active development.
-Items are ordered roughly by dependency (text rendering unlocks most of the rest).
+Items are ordered roughly by dependency.
 
 ---
 
-## 1. Text Rendering (prerequisite for HUD/UI) — IN PROGRESS (PR #55)
+## 1. Text Rendering / HUD
 
-**Blocker for:** score display, game over screen, debug overlay, any menus.
-
-Used `fontdue` (pure Rust font rasterizer) instead of `glyphon` — glyphon doesn't support wgpu 29 yet. Hand-rolled bitmap atlas approach is a better fit for Pixel Six anyway.
+Core text rendering has shipped and is used by the HUD, title, debug overlay,
+and game-over screen. Used `fontdue` (pure Rust font rasterizer) instead of
+`glyphon` — glyphon doesn't support wgpu 29 yet. Hand-rolled bitmap atlas
+approach is a better fit for Pixel Six anyway.
 
 Tasks:
 - [x] Embed Pixel Six font via `include_bytes!` (already in repo from legacy)
@@ -70,12 +71,17 @@ Done: title screen → playing → dead → game over → title flow implemented
 
 Independent — no blockers. More urgent now that iOS is running on device.
 
-Currently the game renders at a fixed internal resolution (240×135) upscaled to fill the window. On iPhone 15 Pro (2556×1179, ~19.5:9) the game viewport doesn't fill the screen correctly — letterboxed or wrong aspect.
+The game renders at a fixed internal resolution and letterboxes into the surface.
+Basic resize works; the remaining architecture work is to centralize surface,
+safe-area, backing-pixel, and game-viewport mapping into `SurfaceMetrics` so
+camera, input, title overlay, and touch UI cannot drift.
 
 Tasks:
 - [x] Decide internal render resolution strategy → camera letterboxes game quad (261×160) into surface; bars on one axis only.
 - [x] Full-screen Metal surface on iOS — see 8d above.
-- [ ] Handle window resize gracefully (resize swapchain, update camera projection)
+- [x] Handle window resize gracefully (resize swapchain, update camera projection)
+- [ ] Add shared `SurfaceMetrics` for surface/game mapping (see
+      `architecture-cleanup.md`)
 - [ ] Optional: expose resolution config in `game_config.toml`
 
 ---
@@ -86,15 +92,19 @@ Fixed: `rand` dep removed, `fastrand::Rng::new().shuffle()` used instead. Level 
 
 ---
 
-## 7. Music: Non-Blocking Track Render (WASM)
+## 7. Music: Web Worker Track Render (WASM)
 
-`render_track` runs synchronously inside `spawn_local` on WASM, blocking the main thread for ~2–4 s while a tracker file decodes. Visible as a freeze when a track loads.
+WASM track rendering now yields in chunks while running from `spawn_local`, so
+the old fully synchronous freeze is no longer the active problem. A Web Worker
+would still be cleaner for large tracker files and keeps audio decode/render
+work off the browser main thread.
 
 Native is already correct (background thread via `std::thread::spawn`).
 
 Tasks:
-- [ ] Move `render_track` to a Web Worker on WASM (see `music.md` Phase 3 for options)
-- [ ] Verify no main-thread freeze when starting / cycling tracks in the browser
+- [ ] Add an explicit user-gesture audio-unlock path for Web Audio.
+- [ ] Move `render_track` to a Web Worker on WASM (see `music.md` Phase 3 for options).
+- [ ] Verify no main-thread hitch when starting / cycling tracks in the browser.
 
 ---
 
@@ -120,20 +130,17 @@ treats the app as a legacy app and runs it in 480×320-point compatibility mode
 (1440×960 px at 3×), centered on the real screen with massive OS-level black
 bars that don't pass touch events. Fixed by adding `<key>UILaunchScreen</key><dict/>`
 to `ios/Info.plist`. Also added:
-- `framework.rs` `init_gpu`: `window.outer_size()` on iOS (safe-area guard) + logging.
-- `framework.rs` `resumed`: landscape lock, hide status bar + home indicator.
+- `src/app.rs` `init_gpu`: `window.outer_size()` on iOS (safe-area guard) + logging.
+- `src/app.rs` `resumed`: landscape lock, hide status bar + home indicator.
 
 ### 8e. In-game settings overlay (longer term)
 See `autonomous-improvement.md` for full design. Lower priority.
 
 ---
 
-## 9. macOS App Packaging — needs rebase + merge
+## 9. macOS App Packaging ✅
 
-Work is complete on the `macos-packaging` branch (diverged from master at
-`a9fa746`, ~23 commits behind). Needs rebase onto master and a PR.
-
-What's on that branch:
+Merged to `master`. Current assets:
 - `macos/Info.plist` — bundle metadata (com.glalonde.spout, Metal, macOS 13+)
 - `scripts/package_macos.sh` — builds release binary, assembles .app, ad-hoc
   or Developer ID signs, optional --dmg flag
@@ -141,10 +148,11 @@ What's on that branch:
   dispatch; uploads .app + .dmg as release artifacts
 - `_context/macos-signing.md` — signing/notarization docs (team HNRULUX5AH)
 
-Steps:
-- [ ] `git checkout macos-packaging && git rebase master`
-- [ ] Resolve any conflicts (likely none — touches different files)
-- [ ] Open PR and merge
+Follow-up:
+- [ ] Release workflow hardening: `.github/workflows/release.yml` and
+      `.github/workflows/release-macos.yml` both trigger on `v*` tags and can
+      race to create/update the GitHub Release. Consolidate release publishing
+      into one final job after Linux/macOS/WASM artifacts are built.
 
 ---
 

--- a/_context/wasm-debugging.md
+++ b/_context/wasm-debugging.md
@@ -68,7 +68,7 @@ panicked at .../std/sys/pal/wasm/../unsupported/time.rs: time not implemented on
 `request_adapter` / `request_device` are JS Promises. `block_on` spins waiting
 for them but never yields control to the JS event loop, so they never resolve.
 **Fix:** use `wasm_bindgen_futures::spawn_local` and share results via
-`Rc<RefCell<Option<T>>>`. See `examples/framework.rs` for the pattern.
+`Rc<RefCell<Option<T>>>`. See `src/app.rs` for the pattern.
 
 ### `getrandom` on WASM
 wgpu 29 transitively requires `getrandom 0.3`, which needs the `wasm_js` feature

--- a/src/color_maps.rs
+++ b/src/color_maps.rs
@@ -59,11 +59,11 @@ fn parula() -> scarlet::colormap::ListedColorMap {
     scarlet::colormap::ListedColorMap::new(PARULA_DATA.iter().copied())
 }
 
-static COLOR_MAPS: OnceLock<[scarlet::colormap::ListedColorMap; 5]> = OnceLock::new();
+static COLOR_MAPS: OnceLock<Vec<scarlet::colormap::ListedColorMap>> = OnceLock::new();
 
-fn color_maps() -> &'static [scarlet::colormap::ListedColorMap; 5] {
+fn color_maps() -> &'static [scarlet::colormap::ListedColorMap] {
     COLOR_MAPS.get_or_init(|| {
-        [
+        vec![
             scarlet::colormap::ListedColorMap::viridis(),
             scarlet::colormap::ListedColorMap::magma(),
             scarlet::colormap::ListedColorMap::inferno(),
@@ -71,6 +71,10 @@ fn color_maps() -> &'static [scarlet::colormap::ListedColorMap; 5] {
             parula(),
         ]
     })
+}
+
+pub fn has_color_map_index(i: usize) -> bool {
+    color_maps().get(i).is_some()
 }
 
 pub fn get_color_map_from_index(i: usize) -> &'static scarlet::colormap::ListedColorMap {
@@ -146,7 +150,7 @@ mod tests {
 
     #[test]
     fn all_color_maps_accessible() {
-        for i in 0..5 {
+        for i in 0..color_maps().len() {
             let _cm = get_color_map_from_index(i);
         }
     }
@@ -154,6 +158,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn out_of_bounds_panics() {
-        let _cm = get_color_map_from_index(5);
+        let _cm = get_color_map_from_index(color_maps().len());
     }
 }

--- a/src/game_params.rs
+++ b/src/game_params.rs
@@ -1,5 +1,7 @@
 //! Game configuration structs deserialized from `game_config.toml`.
 
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Default)]
@@ -17,7 +19,37 @@ pub enum TouchControlScheme {
 }
 
 // Parameters that define the game. These don't change at runtime.
+#[derive(Debug)]
+pub enum GameParamsError {
+    Parse(toml::de::Error),
+    Invalid(String),
+}
+
+impl fmt::Display for GameParamsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GameParamsError::Parse(err) => write!(f, "{err}"),
+            GameParamsError::Invalid(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for GameParamsError {}
+
+impl From<toml::de::Error> for GameParamsError {
+    fn from(value: toml::de::Error) -> Self {
+        GameParamsError::Parse(value)
+    }
+}
+
+// Particle counts are calculated in f32 before being cast to u32 for buffer
+// allocation. Keep validation inside f32's exact integer range so the limit
+// does not depend on rounded large values.
+const MAX_EXACT_PARTICLE_COUNT_F32: f32 = (1_u32 << 24) as f32;
+
+// Parameters that define the game. These don't change at runtime.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(deny_unknown_fields)]
 pub struct GameParams {
     pub viewport_width: u32,
     pub viewport_height: u32,
@@ -45,6 +77,7 @@ pub struct GameParams {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(deny_unknown_fields)]
 pub struct VisualParams {
     /// Index into the particle color map palette (see color_maps.rs).
     pub color_map: i32,
@@ -115,6 +148,7 @@ impl Default for VisualParams {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(deny_unknown_fields)]
 pub struct ParticleSystemParams {
     pub emission_rate: f32,
     pub emission_speed: f32,
@@ -138,6 +172,7 @@ impl Default for ParticleSystemParams {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(deny_unknown_fields)]
 pub struct ShipParams {
     pub acceleration: f32,
     pub rotation_rate: f32,
@@ -155,6 +190,7 @@ impl Default for ShipParams {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(deny_unknown_fields)]
 pub struct LevelParams {
     pub starting_terrain_health: i32,
     #[serde(default = "default_level_time_limit_seconds")]
@@ -171,11 +207,167 @@ impl Default for LevelParams {
 }
 
 impl std::str::FromStr for GameParams {
-    type Err = toml::de::Error;
+    type Err = GameParamsError;
     fn from_str(serialized: &str) -> Result<Self, Self::Err> {
-        let params = toml::from_str(serialized)?;
+        let params: GameParams = toml::from_str(serialized)?;
+        params.validate()?;
         Ok(params)
     }
+}
+
+impl GameParams {
+    pub fn validate(&self) -> Result<(), GameParamsError> {
+        ensure_positive_u32("viewport_width", self.viewport_width)?;
+        ensure_positive_u32("viewport_height", self.viewport_height)?;
+        ensure_positive_u32("level_width", self.level_width)?;
+        ensure_positive_u32("level_height", self.level_height)?;
+        // Width is currently fixed to the viewport because particle/terrain
+        // shaders still conflate terrain stride, view width, and density width.
+        // Height may exceed the viewport because levels scroll vertically.
+        ensure(
+            self.level_width == self.viewport_width,
+            "level_width must equal viewport_width until terrain/view/density widths are split",
+        )?;
+        ensure(
+            self.level_height >= self.viewport_height,
+            "level_height must be at least viewport_height",
+        )?;
+        ensure_positive_f64("fps", self.fps)?;
+
+        let particle_count = self.particle_system_params.emission_rate
+            * self.particle_system_params.max_particle_life;
+        ensure(
+            particle_count.is_finite()
+                && particle_count > 0.0
+                && particle_count <= MAX_EXACT_PARTICLE_COUNT_F32,
+            "particle_system_params.emission_rate * max_particle_life must be finite, positive, and no more than 16,777,216",
+        )?;
+        ensure_positive_f32(
+            "particle_system_params.emission_rate",
+            self.particle_system_params.emission_rate,
+        )?;
+        ensure_positive_f32(
+            "particle_system_params.emission_speed",
+            self.particle_system_params.emission_speed,
+        )?;
+        ensure_positive_f32(
+            "particle_system_params.max_particle_life",
+            self.particle_system_params.max_particle_life,
+        )?;
+        ensure_non_negative_f32(
+            "particle_system_params.damage_rate",
+            self.particle_system_params.damage_rate,
+        )?;
+        ensure_finite_f32(
+            "particle_system_params.gravity",
+            self.particle_system_params.gravity,
+        )?;
+        ensure_non_negative_f32(
+            "particle_system_params.elasticity",
+            self.particle_system_params.elasticity,
+        )?;
+
+        ensure_non_negative_f32("ship_params.acceleration", self.ship_params.acceleration)?;
+        ensure_non_negative_f32("ship_params.rotation_rate", self.ship_params.rotation_rate)?;
+        ensure_positive_f32("ship_params.max_speed", self.ship_params.max_speed)?;
+
+        ensure(
+            self.level_params.starting_terrain_health > 0,
+            "level_params.starting_terrain_health must be positive",
+        )?;
+        ensure_positive_f32(
+            "level_params.level_time_limit_seconds",
+            self.level_params.level_time_limit_seconds,
+        )?;
+
+        ensure(
+            self.visual_params.color_map >= 0
+                && crate::color_maps::has_color_map_index(self.visual_params.color_map as usize),
+            "visual_params.color_map must name an existing color map",
+        )?;
+        ensure_non_negative_f32(
+            "visual_params.bloom_threshold",
+            self.visual_params.bloom_threshold,
+        )?;
+        ensure_non_negative_f32(
+            "visual_params.bloom_strength",
+            self.visual_params.bloom_strength,
+        )?;
+        ensure_positive_u32(
+            "visual_params.bloom_mip_levels",
+            self.visual_params.bloom_mip_levels,
+        )?;
+        ensure_non_negative_f32(
+            "visual_params.crt_strength",
+            self.visual_params.crt_strength,
+        )?;
+        ensure_positive_f32(
+            "visual_params.density_scale",
+            self.visual_params.density_scale,
+        )?;
+        ensure_positive_f32(
+            "visual_params.density_exponent",
+            self.visual_params.density_exponent,
+        )?;
+
+        Ok(())
+    }
+}
+
+fn ensure(condition: bool, message: &'static str) -> Result<(), GameParamsError> {
+    if condition {
+        Ok(())
+    } else {
+        Err(GameParamsError::Invalid(message.to_owned()))
+    }
+}
+
+fn ensure_positive_u32(name: &'static str, value: u32) -> Result<(), GameParamsError> {
+    if value == 0 {
+        return Err(GameParamsError::Invalid(format!(
+            "{name} must be greater than zero"
+        )));
+    }
+
+    Ok(())
+}
+
+fn ensure_finite_f32(name: &'static str, value: f32) -> Result<(), GameParamsError> {
+    if !value.is_finite() {
+        return Err(GameParamsError::Invalid(format!("{name} must be finite")));
+    }
+
+    Ok(())
+}
+
+fn ensure_positive_f32(name: &'static str, value: f32) -> Result<(), GameParamsError> {
+    if !value.is_finite() || value <= 0.0 {
+        return Err(GameParamsError::Invalid(format!(
+            "{name} must be finite and greater than zero"
+        )));
+    }
+
+    Ok(())
+}
+
+fn ensure_non_negative_f32(name: &'static str, value: f32) -> Result<(), GameParamsError> {
+    if !value.is_finite() || value < 0.0 {
+        return Err(GameParamsError::Invalid(format!(
+            "{name} must be finite and non-negative"
+        )));
+    }
+
+    Ok(())
+}
+
+fn ensure_positive_f64(name: &'static str, value: f64) -> Result<(), GameParamsError> {
+    if !value.is_finite() || value <= 0.0 {
+        return Err(GameParamsError::Invalid(format!(
+            "{name} must be finite and greater than zero"
+        )));
+    }
+
+    Ok(())
 }
 
 impl Default for GameParams {
@@ -204,7 +396,12 @@ const EMBEDDED_CONFIG: &str = include_str!("../game_config.toml");
 /// (for development / user overrides), then falls back to the embedded default.
 /// This way packaged .app bundles work without an external config file.
 pub fn get_game_config_from_default_file() -> GameParams {
-    let params = load_params_from_file();
+    let params = match load_params_from_file() {
+        Ok(params) => params,
+        Err(err) => {
+            panic!("embedded game_config.toml is invalid: {err}");
+        }
+    };
     // iOS has no keyboard, so music must default to on (no M-key to toggle).
     #[cfg(target_os = "ios")]
     let params = GameParams {
@@ -214,13 +411,13 @@ pub fn get_game_config_from_default_file() -> GameParams {
     params
 }
 
-fn load_params_from_file() -> GameParams {
+fn load_params_from_file() -> Result<GameParams, GameParamsError> {
     #[cfg(not(target_arch = "wasm32"))]
     if let Ok(disk_config) = std::fs::read_to_string("game_config.toml") {
         match disk_config.parse() {
             Ok(params) => {
                 log::info!("Loaded config from disk: game_config.toml");
-                return params;
+                return Ok(params);
             }
             Err(e) => {
                 log::warn!(
@@ -230,13 +427,11 @@ fn load_params_from_file() -> GameParams {
         }
     }
 
-    match EMBEDDED_CONFIG.parse() {
-        Ok(params) => params,
-        Err(e) => {
-            log::error!("Failed to parse embedded config: {:?}", e);
-            GameParams::default()
-        }
-    }
+    parse_embedded_config()
+}
+
+pub fn parse_embedded_config() -> Result<GameParams, GameParamsError> {
+    EMBEDDED_CONFIG.parse()
 }
 
 #[cfg(test)]
@@ -269,7 +464,10 @@ mod tests {
 
     #[test]
     fn embedded_config_parses() {
-        let params = get_game_config_from_default_file();
+        let params = match parse_embedded_config() {
+            Ok(params) => params,
+            Err(err) => panic!("embedded game_config.toml should parse and validate: {err}"),
+        };
         assert!(params.viewport_width > 0);
         assert!(params.viewport_height > 0);
         assert!(params.fps > 0.0);
@@ -284,6 +482,7 @@ mod tests {
         assert!(d.level_height > d.viewport_height);
         assert!(d.fps > 0.0);
         assert!(d.level_params.level_time_limit_seconds > 0.0);
+        assert!(d.validate().is_ok());
     }
 
     #[test]
@@ -317,5 +516,58 @@ mod tests {
     fn from_str_invalid_toml_returns_error() {
         let bad = "this is not valid toml {{{{";
         assert!(bad.parse::<GameParams>().is_err());
+    }
+
+    #[test]
+    fn from_str_unknown_field_returns_error() {
+        let bad = r#"
+            viewport_width = 100
+            viewport_height = 50
+            level_width = 100
+            level_height = 200
+            fps = 30.0
+            music_starts_on = true
+            render_ship = false
+            typo_that_should_not_be_ignored = true
+        "#;
+        assert!(bad.parse::<GameParams>().is_err());
+    }
+
+    #[test]
+    fn width_mismatch_is_invalid_until_wider_levels_are_split() {
+        let mut params = GameParams::default();
+        params.level_width = params.viewport_width + 1;
+        assert!(params.validate().is_err());
+    }
+
+    #[test]
+    fn invalid_visual_params_are_rejected() {
+        let mut params = GameParams::default();
+        params.visual_params.color_map = i32::MAX;
+        assert!(params.validate().is_err());
+
+        params = GameParams::default();
+        params.visual_params.density_scale = 0.0;
+        assert!(params.validate().is_err());
+
+        params = GameParams::default();
+        params.visual_params.density_exponent = f32::NAN;
+        assert!(params.validate().is_err());
+    }
+
+    #[test]
+    fn invalid_particle_counts_are_rejected() {
+        let mut params = GameParams::default();
+        params.particle_system_params.emission_rate = 0.0;
+        assert!(params.validate().is_err());
+
+        params = GameParams::default();
+        params.particle_system_params.max_particle_life = f32::INFINITY;
+        assert!(params.validate().is_err());
+
+        params = GameParams::default();
+        params.particle_system_params.emission_rate = MAX_EXACT_PARTICLE_COUNT_F32 * 2.0;
+        params.particle_system_params.max_particle_life = 1.0;
+        assert!(params.validate().is_err());
     }
 }

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -15,7 +15,8 @@ pub struct Particle {
     position: [f32; 2],
     velocity: [f32; 2],
     ttl: f32,
-    _padding: i32,
+    // One-frame offset from the uniform particle update dt. 0.0 is neutral.
+    subframe_dt_offset: f32,
 }
 
 struct EmitterParams {
@@ -363,7 +364,7 @@ impl Emitter {
                     base_velocity[1] + speed_vary * angle.sin(),
                 ],
                 ttl,
-                _padding: 0,
+                subframe_dt_offset: 0.0,
             });
         }
 
@@ -1319,6 +1320,10 @@ mod tests {
                 "Burst particle ttl={} expected {}",
                 p.ttl,
                 ttl
+            );
+            assert_eq!(
+                p.subframe_dt_offset, 0.0,
+                "Burst particles should use the neutral subframe_dt_offset"
             );
             // Velocity should include base_vel + radial component.
             let radial_vx = p.velocity[0] - base_vel[0];

--- a/src/shaders/emitter.wgsl
+++ b/src/shaders/emitter.wgsl
@@ -145,5 +145,5 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>, @builtin(num_workgr
     (*particle).position = ship_position + local_rotate_global * local_emit_position; 
     (*particle).velocity = local_rotate_global * local_emit_velocity;
     (*particle).ttl = mix(emit_data.nozzle.ttl_min, emit_data.nozzle.ttl_max, .5); 
-    (*particle).local_dt = emit_data.dt - pass_time;
+    (*particle).subframe_dt_offset = -pass_time;
 }

--- a/src/shaders/particle.wgsl.include
+++ b/src/shaders/particle.wgsl.include
@@ -3,5 +3,6 @@ struct Particle {
   position: vec2<f32>,
   velocity: vec2<f32>,
   ttl: f32,
-  local_dt: f32,
+  // One-frame offset from the uniform particle update dt. 0.0 is neutral.
+  subframe_dt_offset: f32,
 };

--- a/src/shaders/particles.wgsl
+++ b/src/shaders/particles.wgsl
@@ -118,12 +118,11 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>, @builtin(num_workgr
     return;
   } 
 
-  // To get smooth positioning between iterations, some newly emitted particles will have less than the uniform time delta.
-  var dt = uniforms.dt;
-  if ((*particle).local_dt >= 0.0) {
-    dt = (*particle).local_dt;
-    (*particle).local_dt = -1.0;
-  }
+  // New particles can be emitted partway through the frame.
+  // `subframe_dt_offset` adjusts the uniform frame dt once, then resets to the
+  // neutral offset for later updates.
+  let dt = max(uniforms.dt + (*particle).subframe_dt_offset, 0.0);
+  (*particle).subframe_dt_offset = 0.0;
 
   // TODO collisions 
   let signed_delta = (*particle).velocity * dt;


### PR DESCRIPTION
## Summary

This is the base PR in the architecture cleanup stack. It lands the lowest-risk guardrails from the multi-agent architecture review before larger render/platform/simulation refactors.

## What Changed

- Added `GameParams::validate()` and run validation after every TOML parse path.
- Made embedded `game_config.toml` fail fast instead of falling back to `GameParams::default()` when the checked-in config is broken.
- Added `serde(deny_unknown_fields)` to the config structs so typos do not silently disappear.
- Added semantic config tests for width invariants, color map range, density parameters, particle count/lifetime, and checked-in config parsing.
- Changed color map validation to ask the actual color-map slice whether an index exists, so there is no separate count to drift from the palette list.
- Guarded the current GPU width invariant by requiring `level_width == viewport_width` until terrain stride, view width, and density width are split.
- Renamed the particle ABI timing field to `subframe_dt_offset`, documented it as a one-frame dt offset with `0.0` as the neutral value, and removed the sentinel concept.
- Updated GPU emission to write `-pass_time` and particle updates to consume `uniforms.dt + subframe_dt_offset`.
- Added `_context/plans/active/architecture-cleanup.md` as the living plan for the remaining stacked PRs.
- Refreshed stale docs around `src/app.rs`, WASM audio status, basic resize status, and shader constant generation.

## Architecture Review Notes

The review converged on the following stack order:

1. Config and particle ABI guardrails. This PR.
2. Density clear safety. `clear_density_buffer.wgsl` currently needs a dispatch bounds guard for rounded-up workgroups.
3. Collision scheduling. Replace the single pending/in-flight chord model with a `CollisionTracker` or small readback queue.
4. Surface metrics. Centralize surface pixels, game viewport, letterboxing, scale factor, and pointer mapping before extracting broader renderer facades.
5. Render target and frame rendering cleanup. Move formats/targets out of bloom ownership, unify final surface color policy, then extract a behavior-preserving frame renderer.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --verbose`