### PR TITLE
Document terrain overkill semantics

### DIFF
--- a/_context/plans/active/architecture-cleanup.md
+++ b/_context/plans/active/architecture-cleanup.md
@@ -27,6 +27,8 @@ Merged in PRs #77-#84:
       a one-frame dt offset with `0.0` as the neutral value.
 - [x] Guarded `clear_density_buffer.wgsl` against rounded-up workgroup lanes
       and added a non-workgroup-multiple density clear test.
+- [x] Kept particle terrain erosion on the fast atomic decrement path and
+      documented that overkill damage may drive destroyed cells negative.
 
 ## Highest Priority
 
@@ -64,9 +66,10 @@ Merged in PRs #77-#84:
       frame composes terrain, runs particle erosion, then dispatches ship
       collision against the mutated terrain. Keep that if desired, but encode it
       explicitly as `collide_after_erosion` or change the order deliberately.
-- [ ] Make terrain erosion saturating. `try_erode` subtracts damage before
-      checking solidity, so empty cells can become negative terrain. Clamp empty
-      terrain at zero before adding richer material or damage semantics.
+- [ ] Add a frame-boundary terrain clamp only if future systems need
+      nonnegative stored health. Today `try_erode` intentionally uses
+      `atomicAdd` for speed, may drive destroyed cells negative on overkill,
+      and render/collision code treats `<= 0` as empty.
 - [ ] Centralize ship geometry shared by Rust and WGSL so render, collision,
       and emitter offsets cannot drift again.
 - [ ] Rename or hide CPU terrain query helpers that read initial pre-erosion

--- a/src/shaders/particles.wgsl
+++ b/src/shaders/particles.wgsl
@@ -76,7 +76,9 @@ fn get_buffer_offset(cell: vec2<i32>) -> u32 {
 
 // Returns true if bounce occurred.
 fn try_erode(terrain_cell: vec2<i32>, speed: f32) -> bool {
-  let dmg_amt = i32(uniforms.damage_rate * speed);
+  let dmg_amt = max(i32(uniforms.damage_rate * speed), 0);
+  // Overkill damage may drive terrain below zero. Readers treat <= 0 as empty;
+  // add a separate cleanup pass later if storage needs a nonnegative invariant.
   let actual_value = atomicAdd(&terrain_buffer[get_buffer_offset(terrain_cell)], -dmg_amt);
   return actual_value > 0;
 }


### PR DESCRIPTION
## Summary

Third PR in the architecture cleanup stack, stacked on #87.

This updates the terrain-erosion plan after the performance/correctness tradeoff discussion: particle erosion intentionally stays on the fast atomic decrement path. Overkill damage may drive a destroyed cell below zero, and that is acceptable because render/collision readers treat <= 0 as empty.

## What Changed

- Kept try_erode on atomicAdd instead of the compare-exchange saturation loop.
- Clamped computed damage to nonnegative before applying the atomic decrement.
- Added a WGSL comment documenting that negative overkill values are intentional and that a separate cleanup pass can clamp later if needed.
- Updated the active architecture plan to replace the saturating-erosion item with an optional frame-boundary clamp follow-up.

## Verification

- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test --verbose