### PR TITLE
Include bloom tail mip in clamp

### DIFF
--- a/_context/plans/active/architecture-cleanup.md
+++ b/_context/plans/active/architecture-cleanup.md
@@ -27,6 +27,7 @@ Merged in PRs #77-#84:
       a one-frame dt offset with `0.0` as the neutral value.
 - [x] Guarded `clear_density_buffer.wgsl` against rounded-up workgroup lanes
       and added a non-workgroup-multiple density clear test.
+- [x] Fixed bloom mip-level clamping to include the legal 1×1 tail level.
 
 ## Highest Priority
 
@@ -92,7 +93,7 @@ Merged in PRs #77-#84:
 - [ ] Move render-target formats and texture creation out of `bloom.rs` into a
       render-target/formats owner; bloom should consume the HDR format, not own
       the whole game-view contract.
-- [ ] Fix and test bloom mip-level clamping. The current clamp appears to
+- [x] Fix and test bloom mip-level clamping. The current clamp appears to
       undercount the legal 1×1 tail level for power-of-two texture dimensions.
 - [ ] Extract a behavior-preserving `FrameRenderer` facade after `Graphics`.
       `Graphics` currently groups resources, but `Spout::draw_phase` still owns

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -33,7 +33,7 @@ pub const GAME_VIEW_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba16Flo
 /// clamped to this. Floor of 1 — at minimum we need a single mip to render to.
 fn clamp_mip_levels(width: u32, height: u32, requested: u32) -> u32 {
     let half = width.min(height).max(2) / 2;
-    let max_levels = (half as f32).log2().floor() as u32;
+    let max_levels = u32::BITS - half.leading_zeros();
     requested.clamp(1, max_levels.max(1))
 }
 
@@ -374,6 +374,15 @@ mod tests {
     const TEST_H: u32 = 64;
     /// Bytes per pixel for Rgba16Float: 4 channels × 2 bytes (f16) = 8.
     const BPP: u32 = 8;
+
+    #[test]
+    fn clamp_mip_levels_includes_one_pixel_tail() {
+        assert_eq!(clamp_mip_levels(64, 64, 99), 6);
+        assert_eq!(clamp_mip_levels(32, 32, 99), 5);
+        assert_eq!(clamp_mip_levels(3, 3, 99), 1);
+        assert_eq!(clamp_mip_levels(64, 64, 3), 3);
+        assert_eq!(clamp_mip_levels(64, 64, 0), 1);
+    }
 
     fn make_game_view_texture(device: &wgpu::Device) -> wgpu::Texture {
         device.create_texture(&wgpu::TextureDescriptor {


### PR DESCRIPTION
## Summary

Fourth PR in the architecture cleanup stack, now stacked directly on #87 after #88 was closed.

This fixes the bloom mip clamp undercount spotted during the rendering architecture review. A half-resolution bloom pyramid with a 32px smaller dimension can legally use the chain 32 -> 16 -> 8 -> 4 -> 2 -> 1, but the old float log2 calculation returned 5 levels instead of 6.

## What Changed

- Replaced the float log2 clamp with integer mip-count math.
- Kept the existing conservative policy based on the smaller half-resolution dimension.
- Added unit tests covering the one-pixel tail, smaller textures, requested-level clamping, and zero requested levels.
- Updated the active architecture plan to mark the bloom clamp item complete.

## Verification

- cargo fmt --all -- --check
- cargo test bloom --verbose
- cargo clippy -- -D warnings