### PR TITLE
Align terrain uniform signedness

### DIFF
--- a/_context/plans/active/architecture-cleanup.md
+++ b/_context/plans/active/architecture-cleanup.md
@@ -28,6 +28,7 @@ Merged in PRs #77-#84:
 - [x] Guarded `clear_density_buffer.wgsl` against rounded-up workgroup lanes
       and added a non-workgroup-multiple density clear test.
 - [x] Fixed bloom mip-level clamping to include the legal 1×1 tail level.
+- [x] Aligned terrain fragment uniform signedness between Rust and WGSL.
 
 ## Highest Priority
 
@@ -119,9 +120,9 @@ Merged in PRs #77-#84:
       `queue` in `TouchZoneIndicator::new`, and store decoded background tile
       dimensions instead of hardcoding `tile_size: 65.0`.
 - [ ] Align shader ABI names and constants: split particle `view_width`,
-      `density_width`, and `terrain_stride`; make terrain uniform signedness
-      match Rust; resolve dead emitter velocity fields; and move density heat
-      scale into a shared include or build-time constant.
+      `density_width`, and `terrain_stride`; resolve dead emitter velocity
+      fields; and move density heat scale into a shared include or build-time
+      constant.
 
 ## Platform / Boundaries
 

--- a/src/level_manager.rs
+++ b/src/level_manager.rs
@@ -998,6 +998,18 @@ mod tests {
     const TEST_W: u32 = 64;
     const TEST_H: u32 = 32;
 
+    #[test]
+    fn terrain_fragment_uniforms_match_wgsl_layout() {
+        assert_eq!(std::mem::size_of::<FragmentUniforms>(), 16);
+        assert_eq!(std::mem::offset_of!(FragmentUniforms, viewport_width), 0);
+        assert_eq!(std::mem::offset_of!(FragmentUniforms, viewport_height), 4);
+        assert_eq!(std::mem::offset_of!(FragmentUniforms, viewport_offset), 8);
+        assert_eq!(
+            std::mem::offset_of!(FragmentUniforms, terrain_buffer_offset),
+            12
+        );
+    }
+
     /// Render a TerrainRenderer with deterministic stripe data into an offscreen texture,
     /// copy it to the CPU, save a PNG, and optionally compare against a golden image.
     #[test]

--- a/src/shaders/terrain.wgsl
+++ b/src/shaders/terrain.wgsl
@@ -32,8 +32,8 @@ fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 struct Uniforms {
     viewport_width: u32,
     viewport_height: u32,
-    viewport_offset: u32,
-    terrain_buffer_offset: u32,
+    viewport_offset: i32,
+    terrain_buffer_offset: i32,
 };
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 
@@ -45,8 +45,8 @@ fn get_cell_xy(tx: i32, ty: i32) -> i32 {
     if tx < 0 || tx >= i32(uniforms.viewport_width) {
         return 0;
     }
-    let absolute_height = i32(uniforms.viewport_offset) + ty;
-    let row_in_terrain_buffer = absolute_height - i32(uniforms.terrain_buffer_offset);
+    let absolute_height = uniforms.viewport_offset + ty;
+    let row_in_terrain_buffer = absolute_height - uniforms.terrain_buffer_offset;
     let cells_per_row = i32(uniforms.viewport_width);
     let cell_offset = row_in_terrain_buffer * cells_per_row + tx;
     if cell_offset < 0 || u32(cell_offset) >= arrayLength(&terrain_buffer) {


### PR DESCRIPTION
## Summary

Fifth PR in the architecture cleanup stack, now stacked directly on the branch containing #89.

This resolves a small Rust/WGSL ABI drift in the terrain renderer: Rust uploads viewport_offset and terrain_buffer_offset as signed i32, while terrain.wgsl declared those fields as u32 and cast them back at use sites.

## What Changed

- Changed terrain WGSL uniform fields viewport_offset and terrain_buffer_offset from u32 to i32.
- Removed redundant casts in terrain row lookup.
- Added a small Rust layout test for FragmentUniforms offsets and size.
- Updated the active architecture plan to remove terrain uniform signedness from the remaining ABI cleanup list.

## Verification

- cargo fmt --all -- --check
- cargo test terrain --verbose
- cargo clippy -- -D warnings